### PR TITLE
implement codebook hash in sessionVariables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24028,7 +24028,7 @@
       }
     },
     "secure-comms-api": {
-      "version": "git+https://github.com/complexdatacollective/secure-comms-api.git#2123a04dcc4c6a772cb07e6db8e7c88c85ee3cc8",
+      "version": "git+https://github.com/complexdatacollective/secure-comms-api.git#babf3c90f06410ece3ada2568780d82a0949f677",
       "from": "git+https://github.com/complexdatacollective/secure-comms-api.git",
       "dev": true,
       "requires": {

--- a/src/styles/containers/StartScreen/_export-error-list.scss
+++ b/src/styles/containers/StartScreen/_export-error-list.scss
@@ -10,6 +10,7 @@
       margin: 0.75rem;
 
       .icon {
+        flex: 0 0 auto;
         height: unit(3);
         width: unit(3);
         margin-right: unit(2);

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -38,6 +38,7 @@ const apiError = (respJson) => {
 
   // Provide a friendly message, if available.
   if (respJson.message) {
+    error.caseID = respJson.caseID;
     error.friendlyMessage = respJson.message;
     error.code = respJson.code;
     error.stack = null;
@@ -50,7 +51,7 @@ const apiMismatchError = (code, response) => {
   const error = new Error('Device API mismatch');
 
   error.status = ApiMismatchStatus;
-  error.friendlyMessage = 'The device does not match the server API version';
+  error.friendlyMessage = 'The device does not match the server API version. Ensure that Interviewer and Server are running compatible versions.';
   error.code = code;
   error.stack = JSON.stringify(response);
 
@@ -357,13 +358,16 @@ class ApiClient {
           if (axios.isCancel(error)) {
             return;
           }
+
           // Handle errors from the response
           const responseError = getResponseError(error.response);
           if (responseError) {
-            this.emit('error', `${responseError.message}: ${responseError.friendlyMessage}`);
+            this.emit('error', `${sessionList[index].sessionVariables.caseId}: ${responseError.message} - ${responseError.friendlyMessage}`);
+            return;
           }
           // Handle errors with the request
           if (error.request) {
+            // Todo: there are other types of request error!
             this.emit('error', ProgressMessages.NoResponseMessage);
           }
         }).then(() => {

--- a/src/utils/exportProcess.js
+++ b/src/utils/exportProcess.js
@@ -149,7 +149,7 @@ export const exportToFile = (sessionList) => {
 
   const exportPromise = fileExportManager.exportSessions(sessionList, installedProtocols);
 
-  // Attatch the dismisshandler to the toast not that we have exportPromise defined.
+  // Attatch the dismisshandler to the toast now that we have exportPromise defined.
   dispatch(toastActions.updateToast(toastUUID, {
     dismissHandler: () => {
       showCancellationToast();
@@ -223,7 +223,7 @@ export const exportToServer = (sessionList) => {
     }
 
     if (errors.length > 0) {
-      const errorList = errors.map((error, index) => (<li key={index}><Icon name="warning" /> {error}</li>));
+      const errorList = errors.map((error, index) => (<li key={index}><Icon name="warning" />{error}</li>));
 
       dispatch(dialogActions.openDialog({
         type: 'Warning',

--- a/src/utils/networkFormat.js
+++ b/src/utils/networkFormat.js
@@ -1,5 +1,6 @@
 import { omit } from 'lodash';
 import crypto from 'crypto';
+import objectHash from 'object-hash';
 import {
   getEntityAttributes,
   entityAttributesProperty,
@@ -11,6 +12,7 @@ import {
   remoteProtocolProperty,
   sessionProperty,
   caseProperty,
+  codebookHashProperty,
   protocolProperty,
   protocolName,
   sessionStartTimeProperty,
@@ -91,6 +93,7 @@ export const asNetworkWithSessionVariables = (sessionId, session, protocol) => {
   // caseId,
   // sessionId,
   // remoteProtocolID - format Server uniquely identifies protocols by
+  // codebookHash - used to compare server version with local version
   // protocol name
   // interview start and finish. If not available dont include
   // export date
@@ -101,6 +104,7 @@ export const asNetworkWithSessionVariables = (sessionId, session, protocol) => {
     [remoteProtocolProperty]: getRemoteProtocolID(protocol.name),
     [protocolName]: protocol.name,
     [protocolProperty]: session.protocolUID,
+    [codebookHashProperty]: objectHash(protocol.codebook),
     ...(session.startedAt && { [sessionStartTimeProperty]:
       new Date(session.startedAt).toISOString() }),
     ...(session.finishedAt && { [sessionFinishTimeProperty]:


### PR DESCRIPTION
Updates Interviewer to send include `codebookHash` in the session variable properties sent to `network-exporters` and to Server via the API.

Updates the network exporters submodule to encode this data correctly in graphml files.