### PR TITLE
skip bonjour if answer is no

### DIFF
--- a/build-resources/scripts/bonjour.nsh
+++ b/build-resources/scripts/bonjour.nsh
@@ -2,6 +2,7 @@
   IfFileExists $PROGRAMFILES\Bonjour\mDNSResponder.exe bonjour noBonjour
     noBonjour:  
       MessageBox MB_YESNO "This app requires Bonjour to be installed to enable automatic server discovery. Would you like to install it now?" IDYES true
+        goto end
       true: 
         ExecWait 'msiexec /i "resources\build-resources\externals\Bonjour64.msi" /quiet /passive'
         goto end


### PR DESCRIPTION
Makes sure to skip the bonjour installer if the user answers no to "Do you want bonjour", so they aren't asked twice.