### PR TITLE
Update NewFilterableListWrapper to support external filter and change behaviour

### DIFF
--- a/src/components/NewFilterableListWrapper.js
+++ b/src/components/NewFilterableListWrapper.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { get } from 'lodash';
 import objectHash from 'object-hash';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -8,7 +8,7 @@ import { Text } from '@codaco/ui/lib/components/Fields';
 import { entityAttributesProperty } from '../ducks/modules/network';
 import sortOrder from '../utils/sortOrder';
 
-export const getFilteredList = (items, filterTerm, propertyPath = entityAttributesProperty) => {
+export const getFilteredList = (items, filterTerm, propertyPath) => {
   if (!filterTerm) { return items; }
 
   const normalizedFilterTerm = filterTerm.toLowerCase();
@@ -58,7 +58,7 @@ const NewFilterableListWrapper = (props) => {
     if (onFilterChange) { onFilterChange(value); }
   };
 
-  const filteredItems = onFilterChange ? items : getFilteredList(items);
+  const filteredItems = onFilterChange ? items : getFilteredList(items, filterTerm, propertyPath);
 
   const sortedItems = sortOrder([{
     property: sortProperty,

--- a/src/components/NewFilterableListWrapper.js
+++ b/src/components/NewFilterableListWrapper.js
@@ -8,6 +8,25 @@ import { Text } from '@codaco/ui/lib/components/Fields';
 import { entityAttributesProperty } from '../ducks/modules/network';
 import sortOrder from '../utils/sortOrder';
 
+export const getFilteredList = (items, filterTerm, propertyPath = entityAttributesProperty) => {
+  if (!filterTerm) { return items; }
+
+  const normalizedFilterTerm = filterTerm.toLowerCase();
+
+  return items.filter(
+    (item) => {
+      const itemAttributes =
+        propertyPath ? Object.values(get(item, propertyPath, {}))
+          : Object.values(item);
+      // Include in filtered list if any of the attribute property values
+      // include the filter value
+      return itemAttributes.some(
+        property => property && property.toString().toLowerCase().includes(normalizedFilterTerm),
+      );
+    },
+  );
+};
+
 const NewFilterableListWrapper = (props) => {
   const {
     items,
@@ -18,17 +37,11 @@ const NewFilterableListWrapper = (props) => {
     sortableProperties,
     loading,
     onFilterChange,
-    resetFilter,
   } = props;
 
   const [filterTerm, setFilterTerm] = useState(null);
   const [sortProperty, setSortProperty] = useState(initialSortProperty);
   const [sortAscending, setSortAscending] = useState(initialSortDirection === 'asc');
-
-  useEffect(() => {
-    if (resetFilter.every(v => v === false)) { return; }
-    setFilterTerm(null);
-  }, resetFilter);
 
   const handleSetSortProperty = (property) => {
     if (sortProperty === property) {
@@ -42,32 +55,15 @@ const NewFilterableListWrapper = (props) => {
   const handleFilterChange = (event) => {
     const value = event.target.value || null;
     setFilterTerm(value);
-    onFilterChange(value);
+    if (onFilterChange) { onFilterChange(value); }
   };
+
+  const filteredItems = onFilterChange ? items : getFilteredList(items);
 
   const sortedItems = sortOrder([{
     property: sortProperty,
     direction: sortAscending ? 'asc' : 'desc',
-  }], {}, propertyPath)(items);
-
-  const getFilteredAndSortedItemList = () => {
-    if (!filterTerm) { return sortedItems; }
-
-    const normalizedFilterTerm = filterTerm.toLowerCase();
-
-    return sortedItems.filter(
-      (item) => {
-        const itemAttributes =
-          propertyPath ? Object.values(get(item, propertyPath, {}))
-            : Object.values(item);
-        // Include in filtered list if any of the attribute property values
-        // include the filter value
-        return itemAttributes.some(
-          property => property && property.toString().toLowerCase().includes(normalizedFilterTerm),
-        );
-      },
-    );
-  };
+  }], {}, propertyPath)(filteredItems);
 
   const containerVariants = {
     show: {
@@ -101,8 +97,6 @@ const NewFilterableListWrapper = (props) => {
       },
     },
   };
-
-  const sortedAndFilteredList = getFilteredAndSortedItemList();
 
   return (
     <div
@@ -163,7 +157,7 @@ const NewFilterableListWrapper = (props) => {
           ) : (
             <AnimatePresence>
               {
-                sortedAndFilteredList.length > 0 && sortedAndFilteredList.map(item => (
+                sortedItems.length > 0 && sortedItems.map(item => (
                   <motion.div
                     variants={itemVariants}
                     key={item.key || objectHash(item)}
@@ -200,7 +194,7 @@ NewFilterableListWrapper.defaultProps = {
   sortableProperties: [],
   loading: false,
   resetFilter: [],
-  onFilterChange: () => {},
+  onFilterChange: null,
 };
 
 export default NewFilterableListWrapper;

--- a/src/containers/StartScreen/DataExportSection.js
+++ b/src/containers/StartScreen/DataExportSection.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { get, intersection, difference } from 'lodash';
+import { get, difference } from 'lodash';
 import { motion } from 'framer-motion';
 import { useSelector, useDispatch } from 'react-redux';
 import { Button } from '@codaco/ui';
@@ -97,7 +97,7 @@ const DataExportSection = () => {
 
   const [filteredSessions, setFilteredSessions] = useState(formattedSessions);
   const filteredIds = filteredSessions.map(({ sessionUUID }) => sessionUUID);
-  const selectedFilteredIds = intersection(selectedSessions, filteredIds);
+  // const selectedFilteredIds = intersection(selectedSessions, filteredIds);
 
   useEffect(() => {
     const newFilteredSessions = getFilteredList(formattedSessions, filterTerm, null);
@@ -108,7 +108,7 @@ const DataExportSection = () => {
   const exportSessions = (toServer = false) => {
     const exportFunction = toServer ? exportToServer : exportToFile;
 
-    const sessionsToExport = selectedFilteredIds
+    const sessionsToExport = selectedSessions
       .map((session) => {
         const sessionProtocol = installedProtocols[sessions[session].protocolUID];
 
@@ -125,8 +125,9 @@ const DataExportSection = () => {
   if (Object.keys(sessions).length === 0) { return null; }
 
   const isSelectAll = (
-    selectedFilteredIds.length > 0 &&
-    filteredIds.length === selectedFilteredIds.length
+    selectedSessions.length > 0 &&
+    selectedSessions.length === filteredIds.length &&
+    difference(selectedSessions, filteredIds).length === 0
   );
 
   const toggleSelectAll = () => {
@@ -146,8 +147,9 @@ const DataExportSection = () => {
 
   const isUnexportedSelected = (
     unexportedSessions.length > 0 &&
-    selectedFilteredIds.length > 0 &&
-      intersection(unexportedSessions, selectedFilteredIds).length === unexportedSessions.length
+    selectedSessions.length > 0 &&
+    selectedSessions.length === unexportedSessions.length &&
+    difference(selectedSessions, unexportedSessions).length === 0
   );
 
   const toggleSelectUnexported = () => {
@@ -210,15 +212,15 @@ const DataExportSection = () => {
               onChange={toggleSelectAll}
             />
           </div>
-          { selectedFilteredIds.length > 0 &&
-            (<span>{ selectedFilteredIds.length} selected session{ selectedFilteredIds.length > 1 ? ('s') : null }.</span>)}
+          { selectedSessions.length > 0 &&
+            (<span>{ selectedSessions.length} selected session{ selectedSessions.length > 1 ? ('s') : null }.</span>)}
         </motion.div>
       </motion.main>
       <motion.footer layout className="data-export-section__footer">
-        <Button color="neon-coral--dark" onClick={handleDeleteSessions} disabled={selectedFilteredIds.length === 0}>Delete Selected</Button>
+        <Button color="neon-coral--dark" onClick={handleDeleteSessions} disabled={selectedSessions.length === 0}>Delete Selected</Button>
         <div className="action-buttons">
-          { pairedServerConnection === 'ok' && (<Button onClick={() => exportSessions(true)} color="mustard" disabled={pairedServerConnection !== 'ok' || selectedFilteredIds.length === 0}>Export Selected To Server</Button>)}
-          <Button color="platinum" onClick={() => exportSessions(false)} disabled={selectedFilteredIds.length === 0}>Export Selected To File</Button>
+          { pairedServerConnection === 'ok' && (<Button onClick={() => exportSessions(true)} color="mustard" disabled={pairedServerConnection !== 'ok' || selectedSessions.length === 0}>Export Selected To Server</Button>)}
+          <Button color="platinum" onClick={() => exportSessions(false)} disabled={selectedSessions.length === 0}>Export Selected To File</Button>
         </div>
       </motion.footer>
     </Section>

--- a/src/containers/StartScreen/DataExportSection.js
+++ b/src/containers/StartScreen/DataExportSection.js
@@ -126,24 +126,28 @@ const DataExportSection = () => {
 
   useEffect(() => {
     const newFilteredSessions = getFilteredList(formattedSessions, filterTerm, null);
+
     setFilteredSessions(newFilteredSessions);
-    console.log({ selectedSessions, newFilteredSessions });
-    // selectedSessions.filter(() => {});
   }, [filterTerm, selectedSessions]);
 
 
   const exportSessions = (toServer = false) => {
     const exportFunction = toServer ? exportToServer : exportToFile;
+    const filteredIds = filteredSessions.map(({ sessionUUID }) => sessionUUID);
 
-    exportFunction(selectedSessions.map((session) => {
-      const sessionProtocol = installedProtocols[sessions[session].protocolUID];
+    const sessionsToExport = selectedSessions
+      .filter(session => filteredIds.includes(session))
+      .map((session) => {
+        const sessionProtocol = installedProtocols[sessions[session].protocolUID];
 
-      return asNetworkWithSessionVariables(
-        session,
-        sessions[session],
-        sessionProtocol,
-      );
-    }));
+        return asNetworkWithSessionVariables(
+          session,
+          sessions[session],
+          sessionProtocol,
+        );
+      });
+
+    exportFunction(sessionsToExport);
   };
 
   if (Object.keys(sessions).length === 0) { return null; }

--- a/src/containers/StartScreen/DataExportSection.js
+++ b/src/containers/StartScreen/DataExportSection.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { every, get, includes, pickBy } from 'lodash';
 import { motion } from 'framer-motion';
 import { useSelector, useDispatch } from 'react-redux';
@@ -9,7 +9,8 @@ import { Section } from '.';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { actionCreators as dialogActions } from '../../ducks/modules/dialogs';
 import useServerConnectionStatus from '../../hooks/useServerConnectionStatus';
-import { NewFilterableListWrapper, Switch } from '../../components';
+import { Switch } from '../../components';
+import NewFilterableListWrapper, { getFilteredList } from '../../components/NewFilterableListWrapper';
 import { asNetworkWithSessionVariables } from '../../utils/networkFormat';
 import formatDatestamp from '../../utils/formatDatestamp';
 
@@ -17,7 +18,7 @@ const oneBasedIndex = i => parseInt(i || 0, 10) + 1;
 
 const DataExportSection = () => {
   const sessions = useSelector(state => state.sessions);
-
+  const [filterTerm, setFilterTerm] = useState(null);
   const [selectedSessions, setSelectedSessions] = useState([]);
 
   const pairedServer = useSelector(state => state.pairedServer);
@@ -28,7 +29,7 @@ const DataExportSection = () => {
   const deleteSession = id => dispatch(sessionsActions.removeSession(id));
   const openDialog = dialog => dispatch(dialogActions.openDialog(dialog));
 
-  const handleFilterChange = () => setSelectedSessions([]);
+  const handleFilterChange = term => setFilterTerm(term);
 
   const handleDeleteSessions = () => {
     openDialog({
@@ -120,6 +121,17 @@ const DataExportSection = () => {
     };
   });
 
+
+  const [filteredSessions, setFilteredSessions] = useState(formattedSessions);
+
+  useEffect(() => {
+    const newFilteredSessions = getFilteredList(formattedSessions, filterTerm, null);
+    setFilteredSessions(newFilteredSessions);
+    console.log({ selectedSessions, newFilteredSessions });
+    // selectedSessions.filter(() => {});
+  }, [filterTerm, selectedSessions]);
+
+
   const exportSessions = (toServer = false) => {
     const exportFunction = toServer ? exportToServer : exportToFile;
 
@@ -156,7 +168,7 @@ const DataExportSection = () => {
         </motion.div>
         <NewFilterableListWrapper
           ItemComponent={SessionCard}
-          items={formattedSessions}
+          items={filteredSessions}
           propertyPath={null}
           initialSortProperty="updatedAt"
           initialSortDirection="desc"


### PR DESCRIPTION
This change allows filter to operate around export and select all options.

This works by updating `<NewFilterableListWrapper />` to expect list filtering to be managed externally if the `onFilterChange` prop is provided.

- The "original" selection is remembered until you make a change:
  - If you select a toggle, it will only apply that feature to the visible range
  - If you select an individual session it will only change the selection of that individual session, filtered but hidden sessions will remain selected.
- Toggle state is dependent on visible range, if select all or unexported sessions do not match those in the visible range they will be toggled as "off" until that changes.

Resolves https://github.com/complexdatacollective/Interviewer/issues/1117