### PR TITLE
Assume preset.highlight and preset.edges.display can be empty

### DIFF
--- a/src/containers/Canvas/PresetSwitcherKey.js
+++ b/src/containers/Canvas/PresetSwitcherKey.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { get } from 'lodash';
 import { Icon, window } from '@codaco/ui';
 import { Radio } from '@codaco/ui/lib/components/Fields';
 import { Accordion } from '.';
@@ -122,14 +123,18 @@ const makeMapStateToProps = () => {
   const getCategoricalOptions = makeGetCategoricalOptions();
 
   const mapStateToProps = (state, props) => {
-    const highlightLabels = props.preset.highlight.map(variable => (
-      getNodeAttributeLabel(state, { variableId: variable, ...props })
-    ));
-    const edges = props.preset.edges.display.map(type => (
-      { label: getEdgeLabel(state, { type }), color: getEdgeColor(state, { type }) }
-    ));
-    const convexOptions = getCategoricalOptions(state,
-      { variableId: props.preset.groupVariable, ...props });
+    const highlightLabels = get(props, 'preset.highlight', [])
+      .map(variable => (
+        getNodeAttributeLabel(state, { variableId: variable, ...props })
+      ));
+    const edges = get(props, 'preset.edges.display', [])
+      .map(type => (
+        { label: getEdgeLabel(state, { type }), color: getEdgeColor(state, { type }) }
+      ));
+    const convexOptions = getCategoricalOptions(
+      state,
+      { variableId: props.preset.groupVariable, ...props },
+    );
 
     return {
       convexOptions,


### PR DESCRIPTION
Fixes case where `preset.highlight` is empty, and anticipates `preset.edges.display` also potentially being empty.