### PR TITLE
Assume preset.highlight and preset.edges.display can be empty (master)

### DIFF
--- a/src/containers/Canvas/PresetSwitcherKey.js
+++ b/src/containers/Canvas/PresetSwitcherKey.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { Icon, window } from '@codaco/ui';
 import { Radio } from '@codaco/ui/lib/components/Fields';
 import Accordion from './Accordion';
@@ -73,31 +73,37 @@ class PresetSwitcherKey extends Component {
     return (
       <div className={classNames} ref={this.panel}>
         <div className="preset-switcher-key__content">
-          <Accordion label="Attributes" onAccordionToggle={toggleHighlighting}>
-            {highlightLabels.map(this.renderHighlightLabel)}
-          </Accordion>
-          <Accordion label="Links" onAccordionToggle={toggleEdges}>
-            {edges.map((edge, index) => (
-              <div className="accordion-item" key={index}>
-                <Icon
-                  name="links"
-                  color={edge.color}
-                />
-                {edge.label}
-              </div>
-            ))}
-          </Accordion>
-          <Accordion label="Groups" onAccordionToggle={toggleHulls}>
-            {convexOptions.map((option, index) => (
-              <div className="accordion-item" key={index}>
-                <Icon
-                  name="contexts"
-                  color={`cat-color-seq-${index + 1}`}
-                />
-                {option.label}
-              </div>
-            ))}
-          </Accordion>
+          { !isEmpty(highlightLabels) && (
+            <Accordion label="Attributes" onAccordionToggle={toggleHighlighting}>
+              {highlightLabels.map(this.renderHighlightLabel)}
+            </Accordion>
+          )}
+          { !isEmpty(edges) && (
+            <Accordion label="Links" onAccordionToggle={toggleEdges}>
+              {edges.map((edge, index) => (
+                <div className="accordion-item" key={index}>
+                  <Icon
+                    name="links"
+                    color={edge.color}
+                  />
+                  {edge.label}
+                </div>
+              ))}
+            </Accordion>
+          )}
+          { !isEmpty(convexOptions) && (
+            <Accordion label="Groups" onAccordionToggle={toggleHulls}>
+              {convexOptions.map((option, index) => (
+                <div className="accordion-item" key={index}>
+                  <Icon
+                    name="contexts"
+                    color={`cat-color-seq-${index + 1}`}
+                  />
+                  {option.label}
+                </div>
+              ))}
+            </Accordion>
+          )}
         </div>
       </div>
     );

--- a/src/containers/Canvas/PresetSwitcherKey.js
+++ b/src/containers/Canvas/PresetSwitcherKey.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { get } from 'lodash';
 import { Icon, window } from '@codaco/ui';
 import { Radio } from '@codaco/ui/lib/components/Fields';
 import Accordion from './Accordion';
@@ -124,14 +125,18 @@ const makeMapStateToProps = () => {
   const getCategoricalOptions = makeGetCategoricalOptions();
 
   const mapStateToProps = (state, props) => {
-    const highlightLabels = props.preset.highlight.map((variable) => (
-      getNodeAttributeLabel(state, { variableId: variable, ...props })
-    ));
-    const edges = props.preset.edges.display.map((type) => (
-      { label: getEdgeLabel(state, { type }), color: getEdgeColor(state, { type }) }
-    ));
-    const convexOptions = getCategoricalOptions(state,
-      { variableId: props.preset.groupVariable, ...props });
+    const highlightLabels = get(props, 'preset.highlight', [])
+      .map((variable) => (
+        getNodeAttributeLabel(state, { variableId: variable, ...props })
+      ));
+    const edges = get(props, 'preset.edges.display', [])
+      .map((type) => (
+        { label: getEdgeLabel(state, { type }), color: getEdgeColor(state, { type }) }
+      ));
+    const convexOptions = getCategoricalOptions(
+      state,
+      { variableId: props.preset.groupVariable, ...props },
+    );
 
     return {
       convexOptions,

--- a/src/containers/Canvas/__tests__/PresetSwitcherKey.test.js
+++ b/src/containers/Canvas/__tests__/PresetSwitcherKey.test.js
@@ -8,13 +8,18 @@ import { UnconnectedPresetSwitcherKey as PresetSwitcherKey } from '../PresetSwit
 describe('<PresetSwitcherKey />', () => {
   const props = {
     isOpen: true,
-    highlightLabels: [],
-    edges: [],
-    convexOptions: [],
+    highlightLabels: ['mock'],
+    edges: ['mock'],
+    convexOptions: ['mock'],
   };
 
   it('renders accordions of preset options', () => {
     const subject = shallow(<PresetSwitcherKey {...props} />);
-    expect(subject.find('Accordion').length).toBeGreaterThan(1);
+    expect(subject.find('Accordion').length).toEqual(3);
+  });
+
+  it('doesnt render an accordion if the option is empty', () => {
+    const subject = shallow(<PresetSwitcherKey {...props} highlightLabels={[]} />);
+    expect(subject.find('Accordion').length).toEqual(2);
   });
 });


### PR DESCRIPTION
Fixes case where `preset.highlight` is empty, and anticipates `preset.edges.display` also potentially being empty.