### PR TITLE
Release branch for 6.1.1

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget android-versionCode="6074" id="org.codaco.NetworkCanvasInterviewer6" ios-CFBundleIdentifier="org.codaco.networkCanvasInterviewerBusiness" ios-CFBundleVersion="6074" version="6.1.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="6074" id="org.codaco.NetworkCanvasInterviewer6" ios-CFBundleIdentifier="org.codaco.networkCanvasInterviewerBusiness" ios-CFBundleVersion="6074" version="6.1.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>Network Canvas Interviewer</name>
   <description>
         A tool for conducting Network Canvas Interviews.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "network-canvas-interviewer",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "network-canvas-interviewer",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "dependencies": {
         "@babel/runtime": "7.10.1",
         "archiver": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-canvas-interviewer",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "productName": "Network Canvas Interviewer",
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective",

--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-canvas-interviewer",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "productName": "Network Canvas Interviewer",
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective",


### PR DESCRIPTION
## Network Canvas Interviewer 6.1.1

This release contains a fix for a small bug that impacts updating an already installed protocol. It should be installed by all users currently running version 6.1.0. 

If you are running a version prior to 6.1.0, please consult the release notes for that release before updating: https://github.com/complexdatacollective/Interviewer/releases/tag/v6.1.0

### Changelog:

- Fixed an issue where the app would incorrectly inform a user that there were in-progress sessions when attempting to import a protocol.