### PR TITLE
Fix Searchable List sort controls

### DIFF
--- a/src/hooks/__test__/useSort.test.js
+++ b/src/hooks/__test__/useSort.test.js
@@ -1,10 +1,11 @@
+/* eslint-disable @codaco/spellcheck/spell-checker */
 /* eslint-env jest */
 
 import React from 'react';
 import { mount } from 'enzyme';
 import useSort from '../useSort';
 
-const list = [
+const mockList = [
   {
     id: 1,
     data: {
@@ -40,7 +41,7 @@ const sortOrder = {
   direction: 'desc',
 };
 
-const TestConsumer = (props) => {
+const TestConsumer = ({ list, initialSortOrder }) => {
   const [
     sortedList,
     sortByProperty,
@@ -48,8 +49,8 @@ const TestConsumer = (props) => {
     updateSortByProperty,
     toggleSortDirection,
   ] = useSort(
-    props.list,
-    props.initialSortOrder,
+    list,
+    initialSortOrder,
   );
 
   return (
@@ -69,7 +70,7 @@ describe('useSort', () => {
   it('returns correct interface', () => {
     const subject = mount((
       <TestConsumer
-        list={list}
+        list={mockList}
         initialSortOrder={sortOrder}
       />
     ));
@@ -92,7 +93,7 @@ describe('useSort', () => {
   it('can toggle direction', () => {
     const subject = mount((
       <TestConsumer
-        list={list}
+        list={mockList}
         initialSortOrder={sortOrder}
       />
     ));
@@ -121,7 +122,7 @@ describe('useSort', () => {
   it('can change sort property', () => {
     const subject = mount((
       <TestConsumer
-        list={list}
+        list={mockList}
         initialSortOrder={sortOrder}
       />
     ));

--- a/src/hooks/__test__/useSort.test.js
+++ b/src/hooks/__test__/useSort.test.js
@@ -1,0 +1,94 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import useSort from '../useSort';
+
+const list = [
+  {
+    id: 1,
+    data: {
+      name: 'Spock',
+      // last_name: '',
+    },
+  },
+  {
+    id: 2,
+    data: {
+      name: 'Nyota',
+      last_name: 'Uhura',
+    },
+  },
+  {
+    id: 3,
+    data: {
+      name: 'James',
+      last_name: 'Kirk',
+    },
+  },
+  {
+    id: 4,
+    data: {
+      name: 'Montgomery',
+      last_name: 'Scott',
+    },
+  },
+];
+
+const TestConsumer = (props) => {
+  const [
+    sortedList,
+    sortByProperty,
+    sortDirection,
+    updateSortByProperty,
+    toggleSortDirection,
+  ] = useSort(
+    props.list,
+    props.initialSortOrder,
+  );
+
+  return (
+    <div
+      useSort={{
+        sortedList,
+        sortByProperty,
+        sortDirection,
+        updateSortByProperty,
+        toggleSortDirection,
+      }}
+    />
+  );
+};
+
+describe('useSort', () => {
+  it('returns correct interface', () => {
+    const initialSortProperty = ['data', 'name'];
+    const initialSortDirection = 'desc';
+    const subject = mount((
+      <TestConsumer
+        list={list}
+        initialSortOrder={{
+          property: initialSortProperty,
+          direction: initialSortDirection,
+        }}
+      />
+    ));
+
+    const {
+      sortedList,
+      sortByProperty,
+      sortDirection,
+      updateSortByProperty,
+      toggleSortDirection,
+    } = subject.find('div').prop('useSort');
+
+    expect(sortedList).toBeInstanceOf(Array);
+    expect(sortByProperty).toEqual(initialSortProperty);
+    expect(sortDirection).toEqual(initialSortDirection);
+    expect(updateSortByProperty).toBeInstanceOf(Function);
+    expect(toggleSortDirection).toBeInstanceOf(Function);
+  });
+
+  it.todo('can toggle direction');
+  it.todo('can change sort property');
+});

--- a/src/hooks/__test__/useSort.test.js
+++ b/src/hooks/__test__/useSort.test.js
@@ -35,6 +35,11 @@ const list = [
   },
 ];
 
+const sortOrder = {
+  property: ['data', 'name'],
+  direction: 'desc',
+};
+
 const TestConsumer = (props) => {
   const [
     sortedList,
@@ -62,15 +67,10 @@ const TestConsumer = (props) => {
 
 describe('useSort', () => {
   it('returns correct interface', () => {
-    const initialSortProperty = ['data', 'name'];
-    const initialSortDirection = 'desc';
     const subject = mount((
       <TestConsumer
         list={list}
-        initialSortOrder={{
-          property: initialSortProperty,
-          direction: initialSortDirection,
-        }}
+        initialSortOrder={sortOrder}
       />
     ));
 
@@ -83,12 +83,99 @@ describe('useSort', () => {
     } = subject.find('div').prop('useSort');
 
     expect(sortedList).toBeInstanceOf(Array);
-    expect(sortByProperty).toEqual(initialSortProperty);
-    expect(sortDirection).toEqual(initialSortDirection);
+    expect(sortByProperty).toEqual(sortOrder.property);
+    expect(sortDirection).toEqual(sortOrder.direction);
     expect(updateSortByProperty).toBeInstanceOf(Function);
     expect(toggleSortDirection).toBeInstanceOf(Function);
   });
 
-  it.todo('can toggle direction');
-  it.todo('can change sort property');
+  it('can toggle direction', () => {
+    const subject = mount((
+      <TestConsumer
+        list={list}
+        initialSortOrder={sortOrder}
+      />
+    ));
+
+    const {
+      sortedList,
+      toggleSortDirection,
+      sortDirection: initialSortDirection,
+    } = subject.find('div').prop('useSort');
+
+    expect(initialSortDirection).toEqual('desc');
+
+    toggleSortDirection();
+
+    subject.update();
+
+    const {
+      sortedList: reversedSortedList,
+      sortDirection,
+    } = subject.find('div').prop('useSort');
+
+    expect(sortedList.reverse()).toEqual(reversedSortedList);
+    expect(sortDirection).toEqual('asc');
+  });
+
+  it('can change sort property', () => {
+    const subject = mount((
+      <TestConsumer
+        list={list}
+        initialSortOrder={sortOrder}
+      />
+    ));
+
+    const {
+      updateSortByProperty,
+    } = subject.find('div').prop('useSort');
+
+    const {
+      sortDirection: changedSortDirection,
+    } = subject.find('div').prop('useSort');
+
+    expect(changedSortDirection).toEqual('desc');
+
+    updateSortByProperty(['data', 'last_name']);
+
+    subject.update();
+
+    const {
+      sortedList,
+      sortByProperty,
+      sortDirection: resetSortDirection,
+    } = subject.find('div').prop('useSort');
+
+    expect(resetSortDirection).toEqual('asc');
+    expect(sortByProperty).toEqual(['data', 'last_name']);
+    expect(sortedList).toEqual([
+      {
+        data: {
+          last_name: 'Kirk',
+          name: 'James',
+        },
+        id: 3,
+      },
+      {
+        data: {
+          last_name: 'Scott',
+          name: 'Montgomery',
+        },
+        id: 4,
+      },
+      {
+        data: {
+          last_name: 'Uhura',
+          name: 'Nyota',
+        },
+        id: 2,
+      },
+      {
+        data: {
+          name: 'Spock',
+        },
+        id: 1,
+      },
+    ]);
+  });
 });

--- a/src/hooks/useSort.js
+++ b/src/hooks/useSort.js
@@ -6,7 +6,7 @@ const defaultSortOrder = {
   property: null,
 };
 
-const sorter = (property) => (item) => get(item, property);
+const getProperty = (property) => get(property);
 
 /**
  * Sort a list of items
@@ -52,8 +52,8 @@ const useSort = (list, initialSortOrder = defaultSortOrder) => {
   const sortedList = useMemo(() => {
     if (!sortByProperty) { return list; }
     return sortDirection === 'desc'
-      ? sortBy([sorter(sortByProperty)])(list).reverse()
-      : sortBy([sorter(sortByProperty)])(list);
+      ? sortBy([getProperty(sortByProperty)])(list).reverse()
+      : sortBy([getProperty(sortByProperty)])(list);
   }, [list, sortByProperty, sortDirection]);
 
   return [sortedList, sortByProperty, sortDirection, updateSortByProperty, toggleSortDirection];


### PR DESCRIPTION
Very small fix which should resolve sort controls not working in SearchableList.

Also added a test to back it up.

Resolves #1148