### PR TITLE
Automatic node layout on the Sociogram

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "cross-env": "^5.2.0",
         "css-loader": "^3.4.2",
         "csvtojson": "^2.0.8",
+        "d3-force": "~3.0.0",
         "detect-port": "1.1.0",
         "dotenv": "4.0.0",
         "electron": "9.4.4",
@@ -13256,6 +13257,47 @@
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
       "dev": true
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.7",
@@ -48366,6 +48408,35 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "dev": true
+    },
+    "d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true
+    },
+    "d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true
+    },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "dev": true
     },
     "damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^3.4.2",
     "csvtojson": "^2.0.8",
+    "d3-force": "~3.0.0",
     "detect-port": "1.1.0",
     "dotenv": "4.0.0",
     "electron": "9.4.4",

--- a/src/components/Canvas/EdgeLayout.js
+++ b/src/components/Canvas/EdgeLayout.js
@@ -5,16 +5,17 @@ import Edge from '../Edge';
 const viewBoxScale = 100;
 
 class EdgeLayout extends PureComponent {
-  renderEdge = (edge, index) => {
+  renderEdge = (edge) => {
     if (!['key', 'from', 'to', 'type'].every((prop) => prop in edge)) {
       return null;
     }
 
     const {
-      key, type,
+      key,
+      type,
+      from,
+      to,
     } = edge;
-
-    const { from, to } = this.props.positions[index];
 
     return (
       <Edge key={key} from={from} to={to} type={type} viewBoxScale={viewBoxScale} />

--- a/src/components/Canvas/EdgeLayout.js
+++ b/src/components/Canvas/EdgeLayout.js
@@ -5,14 +5,16 @@ import Edge from '../Edge';
 const viewBoxScale = 100;
 
 class EdgeLayout extends PureComponent {
-  renderEdge = (edge) => {
+  renderEdge = (edge, index) => {
     if (!['key', 'from', 'to', 'type'].every((prop) => prop in edge)) {
       return null;
     }
 
     const {
-      key, from, to, type,
+      key, type,
     } = edge;
+
+    const { from, to } = this.props.positions[index];
 
     return (
       <Edge key={key} from={from} to={to} type={type} viewBoxScale={viewBoxScale} />

--- a/src/components/Canvas/NodeLayout.js
+++ b/src/components/Canvas/NodeLayout.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isEmpty, get } from 'lodash';
 import LayoutNode from '../../containers/Canvas/LayoutNode';
 import { entityPrimaryKeyProperty, entityAttributesProperty } from '../../ducks/modules/network';
+import useDropTarget from '../../hooks/useDropTarget';
 
 const NodeLayout = React.forwardRef(({
   nodes,
@@ -14,7 +15,25 @@ const NodeLayout = React.forwardRef(({
   layoutVariable,
   width,
   height,
+  id,
+  meta,
+  accepts,
+  onDrop,
+  onDrag,
+  onDragEnd,
 }, ref) => {
+  useDropTarget(
+    ref,
+    {
+      id,
+      accepts,
+      meta,
+      onDrop,
+      onDrag,
+      onDragEnd,
+    },
+  );
+
   const isHighlighted = useCallback(
     (node) => !isEmpty(highlightAttribute)
         && get(node, [entityAttributesProperty, highlightAttribute]) === true,

--- a/src/components/Canvas/NodeLayout.js
+++ b/src/components/Canvas/NodeLayout.js
@@ -29,7 +29,7 @@ const NodeLayout = React.forwardRef(({
 
   return (
     <div className="node-layout" ref={ref}>
-      { nodes.map((node, index) => {
+      { nodes.map((node, index) => (
         <LayoutNode
           key={node[entityPrimaryKeyProperty]}
           node={node}
@@ -43,7 +43,7 @@ const NodeLayout = React.forwardRef(({
           areaWidth={width}
           areaHeight={height}
         />
-      })}
+      ))}
     </div>
   );
 });

--- a/src/components/Canvas/NodeLayout.js
+++ b/src/components/Canvas/NodeLayout.js
@@ -6,7 +6,6 @@ import { entityPrimaryKeyProperty, entityAttributesProperty } from '../../ducks/
 
 const NodeLayout = React.forwardRef(({
   nodes,
-  positions,
   allowPositioning,
   highlightAttribute,
   connectFrom,
@@ -29,11 +28,10 @@ const NodeLayout = React.forwardRef(({
 
   return (
     <div className="node-layout" ref={ref}>
-      { nodes.map((node, index) => (
+      { nodes.map((node) => (
         <LayoutNode
           key={node[entityPrimaryKeyProperty]}
           node={node}
-          position={positions[index]}
           layoutVariable={layoutVariable}
           onSelected={() => onSelected(node)}
           selected={isHighlighted(node)}

--- a/src/components/Canvas/NodeLayout.js
+++ b/src/components/Canvas/NodeLayout.js
@@ -6,6 +6,7 @@ import { entityPrimaryKeyProperty, entityAttributesProperty } from '../../ducks/
 
 const NodeLayout = React.forwardRef(({
   nodes,
+  positions,
   allowPositioning,
   highlightAttribute,
   connectFrom,
@@ -28,10 +29,11 @@ const NodeLayout = React.forwardRef(({
 
   return (
     <div className="node-layout" ref={ref}>
-      { nodes.map((node) => (
+      { nodes.map((node, index) => {
         <LayoutNode
           key={node[entityPrimaryKeyProperty]}
           node={node}
+          position={positions[index]}
           layoutVariable={layoutVariable}
           onSelected={() => onSelected(node)}
           selected={isHighlighted(node)}
@@ -41,7 +43,7 @@ const NodeLayout = React.forwardRef(({
           areaWidth={width}
           areaHeight={height}
         />
-      ))}
+      })}
     </div>
   );
 });

--- a/src/containers/Canvas/LayoutNode.js
+++ b/src/containers/Canvas/LayoutNode.js
@@ -23,6 +23,7 @@ class LayoutNode extends PureComponent {
       onSelected,
     } = this.props;
     // const nodeAttributes = getEntityAttributes(node);
+    console.log({ position });
 
     const { x, y } = position;
 

--- a/src/containers/Canvas/LayoutNode.js
+++ b/src/containers/Canvas/LayoutNode.js
@@ -13,17 +13,18 @@ const EnhancedNode = compose(
 class LayoutNode extends PureComponent {
   render() {
     const {
+      position,
       allowPositioning,
       allowSelect,
-      layoutVariable,
+      // layoutVariable,
       linking,
       node,
       selected,
       onSelected,
     } = this.props;
-    const nodeAttributes = getEntityAttributes(node);
+    // const nodeAttributes = getEntityAttributes(node);
 
-    const { x, y } = nodeAttributes[layoutVariable];
+    const { x, y } = position;
 
     const styles = {
       left: `${100 * x}%`,

--- a/src/containers/Canvas/LayoutNode.js
+++ b/src/containers/Canvas/LayoutNode.js
@@ -13,18 +13,17 @@ const EnhancedNode = compose(
 class LayoutNode extends PureComponent {
   render() {
     const {
-      position,
       allowPositioning,
       allowSelect,
-      // layoutVariable,
+      layoutVariable,
       linking,
       node,
       selected,
       onSelected,
     } = this.props;
-    // const nodeAttributes = getEntityAttributes(node);
+    const nodeAttributes = getEntityAttributes(node);
 
-    const { x, y } = position;
+    const { x, y } = nodeAttributes[layoutVariable];
 
     const styles = {
       left: `${100 * x}%`,

--- a/src/containers/Canvas/LayoutNode.js
+++ b/src/containers/Canvas/LayoutNode.js
@@ -23,7 +23,6 @@ class LayoutNode extends PureComponent {
       onSelected,
     } = this.props;
     // const nodeAttributes = getEntityAttributes(node);
-    console.log({ position });
 
     const { x, y } = position;
 

--- a/src/containers/Canvas/NodeLayout.js
+++ b/src/containers/Canvas/NodeLayout.js
@@ -75,6 +75,7 @@ const NodeLayout = (props) => {
       x,
       y,
     } = size.current;
+
     updateNode(
       id,
       {},

--- a/src/containers/Canvas/NodeLayout.js
+++ b/src/containers/Canvas/NodeLayout.js
@@ -19,6 +19,7 @@ const accepts = ({ meta }) => meta.itemType === 'POSITIONED_NODE';
 
 const NodeLayout = (props) => {
   const {
+    onChange,
     createEdge,
     updateNode,
     toggleEdge,
@@ -39,8 +40,10 @@ const NodeLayout = (props) => {
   const resetConnectFrom = useCallback(() => setConnectFrom(null), []);
 
   const onDrop = useCallback((item) => {
+    const id = item.meta[entityPrimaryKeyProperty];
+
     updateNode(
-      item.meta[entityPrimaryKeyProperty],
+      id,
       {},
       {
         [layoutVariable]: relativeCoords({
@@ -48,14 +51,20 @@ const NodeLayout = (props) => {
         }, item),
       },
     );
+
+    onChange({
+      type: 'node',
+      id,
+    });
 
     incrementRerenderCount();
   }, [layoutVariable, updateNode, incrementRerenderCount]);
 
   const onDrag = useCallback((item) => {
     if (isNil(item.meta[entityAttributesProperty][layoutVariable])) { return; }
+    const id = item.meta[entityPrimaryKeyProperty];
     updateNode(
-      item.meta[entityPrimaryKeyProperty],
+      id,
       {},
       {
         [layoutVariable]: relativeCoords({
@@ -63,6 +72,11 @@ const NodeLayout = (props) => {
         }, item),
       },
     );
+
+    onChange({
+      type: 'node',
+      id,
+    });
   }, [layoutVariable, updateNode]);
 
   const onDragEnd = useCallback(() => {
@@ -93,6 +107,12 @@ const NodeLayout = (props) => {
         to: nodeId,
         type: createEdge,
       });
+
+      onChange({
+        type: 'edge',
+        from: connectFrom,
+        to: nodeId,
+      });
     }
 
     // Reset the node linking state
@@ -111,6 +131,7 @@ const NodeLayout = (props) => {
   }, [allowHighlighting, highlightAttribute, toggleHighlight]);
 
   const onSelected = useCallback((node) => {
+    console.log({ node, allowHighlighting });
     if (!allowHighlighting) {
       connectNode(node[entityPrimaryKeyProperty]);
     } else {
@@ -127,6 +148,7 @@ const NodeLayout = (props) => {
       onDrop={onDrop}
       onSelected={onSelected}
       rerenderCount={rerenderCount}
+      connectFrom={connectFrom}
       {...props}
     />
   );

--- a/src/containers/Canvas/NodeLayout.js
+++ b/src/containers/Canvas/NodeLayout.js
@@ -17,7 +17,6 @@ const accepts = ({ meta }) => meta.itemType === 'POSITIONED_NODE';
 
 const NodeLayout = (props) => {
   const {
-    onChange,
     createEdge,
     updateNode,
     toggleEdge,
@@ -58,11 +57,6 @@ const NodeLayout = (props) => {
       },
     );
 
-    onChange({
-      type: 'node',
-      id,
-    });
-
     incrementRerenderCount();
   };
 
@@ -85,11 +79,6 @@ const NodeLayout = (props) => {
         }, item),
       },
     );
-
-    onChange({
-      type: 'node',
-      id,
-    });
   };
 
   const onDragEnd = () => {
@@ -119,12 +108,6 @@ const NodeLayout = (props) => {
         from: connectFrom,
         to: nodeId,
         type: createEdge,
-      });
-
-      onChange({
-        type: 'edge',
-        from: connectFrom,
-        to: nodeId,
       });
     }
 

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { get } from 'lodash';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -14,6 +14,7 @@ import PromptObstacle from '../Canvas/PromptObstacle';
 import ButtonObstacle from '../Canvas/ButtonObstacle';
 import { actionCreators as resetActions } from '../../ducks/modules/reset';
 import { makeGetDisplayEdges, makeGetNextUnplacedNode, makeGetPlacedNodes } from '../../selectors/canvas';
+import useForceSimulation from '../../hooks/useForceSimulation';
 
 const withResetInterfaceHandler = withHandlers({
   handleResetInterface: ({
@@ -50,6 +51,29 @@ const Sociogram = (props) => {
     nextUnplacedNode,
     edges,
   } = props;
+
+  const handler = (event) => {
+    console.log({ event });
+    switch (event.data.type) {
+      case 'tick':
+        break;
+      case 'end':
+        break;
+      default:
+    }
+  };
+
+  const [initLayoutEngine] = useForceSimulation(handler);
+
+  useEffect(() => {
+    console.log('hi');
+    initLayoutEngine({
+      data: {
+        nodes: [],
+        links: [],
+      },
+    });
+  }, []);
 
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { get } from 'lodash';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -52,6 +52,8 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
+  const [enableAutoLayout, setEnableAutoLayout] = useState(true);
+
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);
   const createEdge = get(prompt, 'edges.create');
@@ -71,7 +73,7 @@ const Sociogram = (props) => {
     autoLayoutNodes,
     autoLayoutEdges,
     startLayout,
-  ] = useAutoLayout(layoutVariable, nodes, edges);
+  ] = useAutoLayout(layoutVariable, nodes, edges, enableAutoLayout);
 
   useEffect(() => {
     startLayout();
@@ -121,6 +123,12 @@ const Sociogram = (props) => {
           label="RESET"
           size="small"
           onClick={handleResetInterface}
+        />
+        <ButtonObstacle
+          id="ENABLE_AUTO_LAYOUT"
+          label="Enable auto layout"
+          size="small"
+          onClick={() => setEnableAutoLayout((v) => !v)}
         />
       </div>
     </div>

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -52,7 +52,7 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
-  const [_nodes, _edges] = useAutoLayout(undefined, nodes, edges);
+  const [nodePositions] = useAutoLayout(undefined, nodes, edges);
 
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);
@@ -88,10 +88,11 @@ const Sociogram = (props) => {
             image={backgroundImage}
           />
           <EdgeLayout
-            edges={_edges}
+            edges={edges}
           />
           <NodeLayout
-            nodes={_nodes}
+            nodes={nodes}
+            positions={nodePositions}
             id="NODE_LAYOUT"
             highlightAttribute={highlightAttribute}
             layoutVariable={layoutVariable}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -52,8 +52,6 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
-  const [enableAutoLayout, setEnableAutoLayout] = useState(false);
-
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);
   const createEdge = get(prompt, 'edges.create');
@@ -70,9 +68,32 @@ const Sociogram = (props) => {
 
   // Automatic Layout
   const [
-    autoLayoutNodes,
-    autoLayoutEdges,
-  ] = useAutoLayout(layoutVariable, nodes, edges, enableAutoLayout);
+    positionedNodes,
+    positionedEdges,
+    scale,
+    isLayoutRunning,
+    startLayout,
+    stopLayout,
+    updateLayout,
+  ] = useAutoLayout();
+
+  const enableAutoLayout = true;
+
+  const displayNodes = enableAutoLayout ? positionedNodes : nodes;
+  const displayEdges = enableAutoLayout ? positionedEdges : edges;
+
+  useEffect(() => {
+    if (nodes.length < 1) { return; }
+    startLayout({
+      nodes,
+      edges,
+    });
+
+    setInterval(() => {
+      console.log(positionedNodes.current && positionedNodes.current[0]);
+    }, 1000);
+  }, [nodes.length]);
+
 
   return (
     <div className="sociogram-interface">
@@ -94,10 +115,10 @@ const Sociogram = (props) => {
             image={backgroundImage}
           />
           <EdgeLayout
-            edges={autoLayoutEdges}
+            edges={displayEdges}
           />
           <NodeLayout
-            nodes={autoLayoutNodes}
+            nodes={displayNodes}
             id="NODE_LAYOUT"
             highlightAttribute={highlightAttribute}
             layoutVariable={layoutVariable}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -14,7 +14,7 @@ import PromptObstacle from '../Canvas/PromptObstacle';
 import ButtonObstacle from '../Canvas/ButtonObstacle';
 import { actionCreators as resetActions } from '../../ducks/modules/reset';
 import { makeGetDisplayEdges, makeGetNextUnplacedNode, makeGetPlacedNodes } from '../../selectors/canvas';
-import useForceSimulation from '../../hooks/useForceSimulation';
+import useAutoLayout from './useAutoLayout';
 
 const withResetInterfaceHandler = withHandlers({
   handleResetInterface: ({
@@ -52,28 +52,7 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
-  const handler = (event) => {
-    console.log({ event });
-    switch (event.data.type) {
-      case 'tick':
-        break;
-      case 'end':
-        break;
-      default:
-    }
-  };
-
-  const [initLayoutEngine] = useForceSimulation(handler);
-
-  useEffect(() => {
-    console.log('hi');
-    initLayoutEngine({
-      data: {
-        nodes: [],
-        links: [],
-      },
-    });
-  }, []);
+  const [_nodes, _edges] = useAutoLayout(undefined, nodes, edges);
 
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);
@@ -109,10 +88,10 @@ const Sociogram = (props) => {
             image={backgroundImage}
           />
           <EdgeLayout
-            edges={edges}
+            edges={_edges}
           />
           <NodeLayout
-            nodes={nodes}
+            nodes={_nodes}
             id="NODE_LAYOUT"
             highlightAttribute={highlightAttribute}
             layoutVariable={layoutVariable}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -118,19 +118,29 @@ const Sociogram = (props) => {
     type,
     data,
   }) => {
+    // updateLayout({
+    //   nodes,
+    //   edges,
+    // });
+
+    // switch (type) {
+    //   case 'node':
+    //     break;
+    //   case 'edge':
+    //     break;
+    //   default:
+    // }
+  };
+
+
+
+  useEffect(() => {
+    console.log(nodes);
     updateLayout({
       nodes,
       edges,
     });
-
-    switch (type) {
-      case 'node':
-        break;
-      case 'edge':
-        break;
-      default:
-    }
-  };
+  }, [nodes, edges]);
 
   return (
     <div className="sociogram-interface">

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -36,7 +36,7 @@ const withPromptIdAsKey = withPropsOnChange(
   (props) => ({ key: props.promptId }),
 );
 
-const useRafState = (initialState, getValue) => {
+const useAnimatedState = (initialState, getValue) => {
   const [state, setState] = useState(initialState);
   const raf = useRef();
 
@@ -96,8 +96,8 @@ const Sociogram = (props) => {
     { layout: layoutVariable },
   );
 
-  const displayNodes = useRafState([], () => positionedNodes.current);
-  const displayEdges = useRafState([], () => positionedEdges.current);
+  const displayNodes = useAnimatedState([], () => positionedNodes.current);
+  const displayEdges = useAnimatedState([], () => positionedEdges.current);
 
   useEffect(() => {
     if (nodes.length < 1) { return () => {}; }

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -110,7 +110,15 @@ const Sociogram = (props) => {
     return () => stopLayout();
   }, [nodes.length]);
 
-  const callback = ({ type, data }) => {
+  const callback = ({
+    type,
+    data,
+  }) => {
+    updateLayout({
+      nodes,
+      edges,
+    });
+
     switch (type) {
       case 'node':
         break;

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -52,7 +52,7 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
-  const [enableAutoLayout, setEnableAutoLayout] = useState(true);
+  const [enableAutoLayout, setEnableAutoLayout] = useState(false);
 
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -1,4 +1,8 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+} from 'react';
 import { get } from 'lodash';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -99,18 +103,18 @@ const Sociogram = (props) => {
   const displayNodes = useAnimatedState([], () => positionedNodes.current);
   const displayEdges = useAnimatedState([], () => positionedEdges.current);
 
-  useEffect(() => {
-    if (nodes.length < 1) { return () => {}; }
+  // useEffect(() => {
+  //   if (nodes.length < 1) { return () => {}; }
 
-    startLayout({
-      nodes,
-      edges,
-    });
+  //   startLayout({
+  //     nodes,
+  //     edges,
+  //   });
 
-    return () => stopLayout();
-  }, [nodes.length]);
+  //   return () => stopLayout();
+  // }, [nodes.length]);
 
-  const callback = ({
+  const handleLayoutChange = ({
     type,
     data,
   }) => {
@@ -158,7 +162,7 @@ const Sociogram = (props) => {
             allowHighlighting={allowHighlighting && !createEdge}
             allowPositioning={allowPositioning}
             createEdge={createEdge}
-            onChange={callback}
+            onChange={handleLayoutChange}
           />
           <NodeBucket
             id="NODE_BUCKET"

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -97,7 +97,7 @@ const Sociogram = (props) => {
   );
 
   const displayNodes = useRafState([], () => positionedNodes.current);
-  const displayEdges = useRafState([], () => displayEdges.current);
+  const displayEdges = useRafState([], () => positionedEdges.current);
 
   useEffect(() => {
     if (nodes.length < 1) { return () => {}; }

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -52,13 +52,6 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
-  const [nodePositions, edgePositions, startLayout] = useAutoLayout(undefined, nodes, edges);
-  // console.log({ nodePositions });
-
-  useEffect(() => {
-    startLayout();
-  }, []);
-
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);
   const createEdge = get(prompt, 'edges.create');
@@ -72,6 +65,14 @@ const Sociogram = (props) => {
   const backgroundImage = get(stage, 'background.image');
   const concentricCircles = get(stage, 'background.concentricCircles');
   const skewedTowardCenter = get(stage, 'background.skewedTowardCenter');
+
+  // Automatic Layout
+  const [autoLayoutNodes, edgePositions, startLayout] = useAutoLayout(layoutVariable, nodes, edges);
+
+  useEffect(() => {
+    startLayout();
+  }, []);
+
 
   return (
     <div className="sociogram-interface">
@@ -95,17 +96,16 @@ const Sociogram = (props) => {
           {/* <EdgeLayout
             edges={edges}
             positions={edgePositions}
-          />
+          />*/}
           <NodeLayout
-            nodes={nodes}
-            positions={nodePositions}
+            nodes={autoLayoutNodes}
             id="NODE_LAYOUT"
             highlightAttribute={highlightAttribute}
             layoutVariable={layoutVariable}
             allowHighlighting={allowHighlighting && !createEdge}
             allowPositioning={allowPositioning}
             createEdge={createEdge}
-          /> */}
+          />
           <NodeBucket
             id="NODE_BUCKET"
             node={nextUnplacedNode}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -67,12 +67,15 @@ const Sociogram = (props) => {
   const skewedTowardCenter = get(stage, 'background.skewedTowardCenter');
 
   // Automatic Layout
-  const [autoLayoutNodes, edgePositions, startLayout] = useAutoLayout(layoutVariable, nodes, edges);
+  const [
+    autoLayoutNodes,
+    autoLayoutEdges,
+    startLayout,
+  ] = useAutoLayout(layoutVariable, nodes, edges);
 
   useEffect(() => {
     startLayout();
   }, []);
-
 
   return (
     <div className="sociogram-interface">
@@ -93,10 +96,9 @@ const Sociogram = (props) => {
             skewedTowardCenter={skewedTowardCenter}
             image={backgroundImage}
           />
-          {/* <EdgeLayout
-            edges={edges}
-            positions={edgePositions}
-          />*/}
+          <EdgeLayout
+            edges={autoLayoutEdges}
+          />
           <NodeLayout
             nodes={autoLayoutNodes}
             id="NODE_LAYOUT"

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -110,6 +110,16 @@ const Sociogram = (props) => {
     return () => stopLayout();
   }, [nodes.length]);
 
+  const callback = ({ type, data }) => {
+    switch (type) {
+      case 'node':
+        break;
+      case 'edge':
+        break;
+      default:
+    }
+  };
+
   return (
     <div className="sociogram-interface">
       <PromptObstacle
@@ -140,6 +150,7 @@ const Sociogram = (props) => {
             allowHighlighting={allowHighlighting && !createEdge}
             allowPositioning={allowPositioning}
             createEdge={createEdge}
+            onChange={callback}
           />
           <NodeBucket
             id="NODE_BUCKET"

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -52,8 +52,12 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
-  const [nodePositions, edgePositions] = useAutoLayout(undefined, nodes, edges);
+  const [nodePositions, edgePositions, startLayout] = useAutoLayout(undefined, nodes, edges);
   // console.log({ nodePositions });
+
+  useEffect(() => {
+    startLayout();
+  }, []);
 
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);
@@ -88,7 +92,7 @@ const Sociogram = (props) => {
             skewedTowardCenter={skewedTowardCenter}
             image={backgroundImage}
           />
-          <EdgeLayout
+          {/* <EdgeLayout
             edges={edges}
             positions={edgePositions}
           />
@@ -101,7 +105,7 @@ const Sociogram = (props) => {
             allowHighlighting={allowHighlighting && !createEdge}
             allowPositioning={allowPositioning}
             createEdge={createEdge}
-          />
+          /> */}
           <NodeBucket
             id="NODE_BUCKET"
             node={nextUnplacedNode}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -72,12 +72,7 @@ const Sociogram = (props) => {
   const [
     autoLayoutNodes,
     autoLayoutEdges,
-    startLayout,
   ] = useAutoLayout(layoutVariable, nodes, edges, enableAutoLayout);
-
-  useEffect(() => {
-    startLayout();
-  }, []);
 
   return (
     <div className="sociogram-interface">

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -73,6 +73,9 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
+  const [enableAutoLayout, setEnableAutoLayout] = useState(false);
+  const toggleEnableAutoLayout = () => setEnableAutoLayout((v) => !v);
+
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);
   const createEdge = get(prompt, 'edges.create');
@@ -103,39 +106,20 @@ const Sociogram = (props) => {
   const displayNodes = useAnimatedState([], () => positionedNodes.current);
   const displayEdges = useAnimatedState([], () => positionedEdges.current);
 
-  // useEffect(() => {
-  //   if (nodes.length < 1) { return () => {}; }
+  useEffect(() => {
+    if (enableAutoLayout) {
+      startLayout({
+        nodes,
+        edges,
+      });
+    } else {
+      stopLayout();
+    }
 
-  //   startLayout({
-  //     nodes,
-  //     edges,
-  //   });
-
-  //   return () => stopLayout();
-  // }, [nodes.length]);
-
-  const handleLayoutChange = ({
-    type,
-    data,
-  }) => {
-    // updateLayout({
-    //   nodes,
-    //   edges,
-    // });
-
-    // switch (type) {
-    //   case 'node':
-    //     break;
-    //   case 'edge':
-    //     break;
-    //   default:
-    // }
-  };
-
-
+    return () => stopLayout();
+  }, [enableAutoLayout]);
 
   useEffect(() => {
-    console.log(nodes);
     updateLayout({
       nodes,
       edges,
@@ -172,7 +156,6 @@ const Sociogram = (props) => {
             allowHighlighting={allowHighlighting && !createEdge}
             allowPositioning={allowPositioning}
             createEdge={createEdge}
-            onChange={handleLayoutChange}
           />
           <NodeBucket
             id="NODE_BUCKET"
@@ -192,7 +175,7 @@ const Sociogram = (props) => {
           id="ENABLE_AUTO_LAYOUT"
           label="Enable auto layout"
           size="small"
-          onClick={() => setEnableAutoLayout((v) => !v)}
+          onClick={toggleEnableAutoLayout}
         />
       </div>
     </div>

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -53,6 +53,7 @@ const Sociogram = (props) => {
   } = props;
 
   const [nodePositions] = useAutoLayout(undefined, nodes, edges);
+  // console.log({ nodePositions });
 
   // Behaviour Configuration
   const allowHighlighting = get(prompt, 'highlight.allowHighlighting', false);

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -52,7 +52,7 @@ const Sociogram = (props) => {
     edges,
   } = props;
 
-  const [nodePositions] = useAutoLayout(undefined, nodes, edges);
+  const [nodePositions, edgePositions] = useAutoLayout(undefined, nodes, edges);
   // console.log({ nodePositions });
 
   // Behaviour Configuration
@@ -90,6 +90,7 @@ const Sociogram = (props) => {
           />
           <EdgeLayout
             edges={edges}
+            positions={edgePositions}
           />
           <NodeLayout
             nodes={nodes}

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -10,8 +10,6 @@ const asXY = (layout, scale) => {
   const minY = scale.minY || 0;
 
   return (node) => {
-    console.log({ entityAttributesProperty, layout });
-
     const {
       x,
       y,

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -98,8 +98,8 @@ const useAutoLayout = (layout, nodes, edges) => {
   const animation = useRef(null);
   const update = useRef(() => {});
   const indexes = useMemo(() => getIndexes(nodes), [nodes]);
-  const [positionedNodes, setPositionedNodes] = useState();
-  const [positionedEdges, setPositionedEdges] = useState();
+  const [positionedNodes, setPositionedNodes] = useState(nodes);
+  const [positionedEdges, setPositionedEdges] = useState(edges);
 
   const [
     simulationState,

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -146,6 +146,7 @@ const useAutoLayout = (layout, nodes, edges, enabled) => {
   useEffect(() => {
     if (!enabled) {
       window.cancelAnimationFrame(animation.current);
+      return;
     }
 
     start();

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -202,8 +202,6 @@ const useAutoLayout = (layoutOptions = {}, simulationOptions = {}) => {
 
     const simulationNodes = asXYs(layout, scale, nodes.current);
 
-    console.log({ simulationNodes, nodes: nodes.current, links: links.current });
-
     startSimulation({
       nodes: simulationNodes,
       links: links.current,
@@ -218,9 +216,9 @@ const useAutoLayout = (layoutOptions = {}, simulationOptions = {}) => {
     indexes.current = getIndexes(layout, nodes.current);
     links.current = asLinks(indexes.current, edges.current);
 
-    const simulationNodes = asXYs(layout, scale, nodes.current);
+    console.log({ scale: scale.current, n: nodes.current });
 
-    console.log({ simulationNodes, nodes: nodes.current, links });
+    const simulationNodes = asXYs(layout, scale, nodes.current);
 
     updateSimulation({
       nodes: simulationNodes,

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -71,19 +71,18 @@ const useAutoLayout = (layout, nodes, edges) => {
       maxY: null,
     });
 
-    const renderNodes = nodes.map((_, index) => ({
+    const nodePositions = nodes.map((_, index) => ({
       x: 0.1 + (engineNodes[index].x - mmd.minX) / mmd.dX * 0.8,
       y: 0.1 + (engineNodes[index].y - mmd.minY) / mmd.dY * 0.8,
     }));
 
-    // const renderEdges = edges.map((edge, index) => ({
-    //   ...edge,
-    //   from: renderNodes[links[index].source].attributes[LAYOUT],
-    //   to: renderNodes[links[index].target].attributes[LAYOUT],
-    // }));
+    const edgePositions = links.map(({ source, target }) => ({
+      from: nodePositions[source],
+      to: nodePositions[target],
+    }));
 
-    setPositionedNodes(renderNodes);
-    // setPositionedEdges(renderEdges);
+    setPositionedNodes(nodePositions);
+    setPositionedEdges(edgePositions);
   };
 
   useEffect(() => {
@@ -103,7 +102,7 @@ const useAutoLayout = (layout, nodes, edges) => {
     return () => window.cancelAnimationFrame(animation.current);
   }, [isRunning]);
 
-  return [positionedNodes];
+  return [positionedNodes, positionedEdges];
 };
 
 export default useAutoLayout;

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import { noop } from 'lodash';
 import { entityPrimaryKeyProperty, entityAttributesProperty } from '../../ducks/modules/network';
 import useForceSimulation from '../../hooks/useForceSimulation';
 
@@ -94,7 +95,7 @@ export const transformLayout = (layout, nodes, edges, nodePositions, links) => {
   ];
 };
 
-const useAutoLayout = (layout, nodes, edges) => {
+const useAutoLayout = (layout, nodes, edges, enabled) => {
   const animation = useRef(null);
   const update = useRef(() => {});
   const indexes = useMemo(() => getIndexes(nodes), [nodes]);
@@ -141,6 +142,18 @@ const useAutoLayout = (layout, nodes, edges) => {
 
     return () => window.cancelAnimationFrame(animation.current);
   }, [isSimulationRunning]);
+
+  useEffect(() => {
+    if (!enabled) {
+      window.cancelAnimationFrame(animation.current);
+    }
+
+    start();
+  }, [enabled]);
+
+  if (!enabled) {
+    return [nodes, edges, noop];
+  }
 
   return [positionedNodes, positionedEdges, start];
 };

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -115,8 +115,8 @@ const useAutoLayout = (layoutOptions = {}, simulationOptions = {}) => {
         edges.current = edges.current.map((edge) => {
           const fromKey = get(indexes.current, edge.ids.from);
           const toKey = get(indexes.current, edge.ids.to);
-          const from = get(positions, [fromKey], edge.from);
-          const to = get(positions, [toKey], edge.to);
+          const from = get(positions.current, [fromKey], edge.from);
+          const to = get(positions.current, [toKey], edge.to);
 
           return {
             ...edge,

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -224,7 +224,6 @@ const useAutoLayout = (layoutOptions = {}, simulationOptions = {}) => {
 
     updateSimulation({
       nodes: simulationNodes,
-      // nodes: nodes.current.map(asXY(layoutOptions.layout, scale)),
       links: links.current,
     });
   }, [scale]);

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -1,4 +1,9 @@
-import { useState, useEffect, useRef } from 'react';
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import useForceSimulation from '../../hooks/useForceSimulation';
 
 const LAYOUT = 'ee090c9b-2b70-4648-a6db-328d4ef4dbfe';
@@ -17,97 +22,120 @@ const asLinks = (indexes) => (edge) => ({
   target: indexes[edge.ids.to],
 });
 
+const getScaledPositions = (nodePositions) => {
+  const scale = nodePositions.reduce((memo, coords, index) => {
+    const minX = memo.minX === null || coords.x < memo.minX ? coords.x : memo.minX;
+    const minY = memo.minY === null || coords.y < memo.minY ? coords.y : memo.minY;
+    const maxX = memo.maxX === null || coords.x > memo.maxX ? coords.x : memo.maxX;
+    const maxY = memo.maxY === null || coords.y > memo.maxY ? coords.y : memo.maxY;
+
+    if (index === nodePositions.length - 1) {
+      const dX = maxX - minX;
+      const dY = maxY - minY;
+
+      return {
+        dX,
+        dY,
+        minY,
+        minX,
+      };
+    }
+
+    return {
+      minX,
+      minY,
+      maxX,
+      maxY,
+    };
+  }, {
+    minX: null,
+    maxX: null,
+    minY: null,
+    maxY: null,
+  });
+
+  return nodePositions.map((position) => ({
+    x: 0.1 + (position.x - scale.minX) / scale.dX * 0.8,
+    y: 0.1 + (position.y - scale.minY) / scale.dY * 0.8,
+  }));
+};
+
+export const transformLayout = (layout, nodes, edges, nodePositions, links) => {
+  const scaledPositions = getScaledPositions(nodePositions);
+
+  const transformedNodes = nodes.map((node, index) => ({
+    ...node,
+    attributes: {
+      ...node.attributes,
+      [layout]: scaledPositions[index],
+    },
+  }));
+
+  const transformedEdges = edges.map((edge, index) => {
+    const { source, target } = links[index];
+
+    return {
+      ...edge,
+      from: scaledPositions[source],
+      to: scaledPositions[target],
+    };
+  });
+
+  return [
+    transformedNodes,
+    transformedEdges,
+  ];
+};
+
 const useAutoLayout = (layout, nodes, edges) => {
   const animation = useRef(null);
   const update = useRef(() => {});
-  const indexes = getIndexes(nodes);
-  const links = edges.map(asLinks(indexes));
-  const [positionedNodes, setPositionedNodes] = useState(nodes.map(asXY()));
-  const [positionedEdges, setPositionedEdges] = useState(links);
+  const indexes = useMemo(() => getIndexes(nodes), [nodes]);
+  const [positionedNodes, setPositionedNodes] = useState();
+  const [positionedEdges, setPositionedEdges] = useState();
 
   const [
-    layoutEngineState,
-    isRunning,
-    initLayoutEngine,
-    startLayoutEngine,
+    simulationState,
+    isSimulationRunning,
+    startSimulation,
   ] = useForceSimulation();
 
-  const updatePositions = () => {
-    const engineNodes = layoutEngineState.current.nodes;
-
-    const mmd = engineNodes.reduce((memo, coords, index) => {
-      const minX = memo.minX === null || coords.x < memo.minX ? coords.x : memo.minX;
-      const minY = memo.minY === null || coords.y < memo.minY ? coords.y : memo.minY;
-      const maxX = memo.maxX === null || coords.x > memo.maxX ? coords.x : memo.maxX;
-      const maxY = memo.maxY === null || coords.y > memo.maxY ? coords.y : memo.maxY;
-
-      if (index === engineNodes.length - 1) {
-        const dX = maxX - minX;
-        const dY = maxY - minY;
-
-        return {
-          dX,
-          dY,
-          minY,
-          minX,
-        };
-      }
-
-      return {
-        minX,
-        minY,
-        maxX,
-        maxY,
-      };
-    }, {
-      minX: null,
-      maxX: null,
-      minY: null,
-      maxY: null,
+  const start = () => {
+    startSimulation({
+      nodes: nodes.map(asXY()),
+      links: edges.map(asLinks(indexes)),
     });
-
-    const nodePositions = nodes.map((_, index) => ({
-      x: 0.1 + (engineNodes[index].x - mmd.minX) / mmd.dX * 0.8,
-      y: 0.1 + (engineNodes[index].y - mmd.minY) / mmd.dY * 0.8,
-    }));
-
-    const edgePositions = links.map(({ source, target }) => ({
-      from: nodePositions[source],
-      to: nodePositions[target],
-    }));
-
-    setPositionedNodes(nodePositions);
-    setPositionedEdges(edgePositions);
   };
 
   update.current = () => {
-    if (isRunning) {
+    if (isSimulationRunning) {
       window.requestAnimationFrame(() => update.current());
     }
 
-    if (!layoutEngineState.current) { return; }
+    if (!simulationState.current) { return; }
 
-    updatePositions();
+    const [
+      transformedNodes,
+      transformedEdges,
+    ] = transformLayout(
+      layout,
+      nodes,
+      edges,
+      simulationState.current.nodes,
+      simulationState.current.links,
+    );
+
+    setPositionedNodes(transformedNodes);
+    setPositionedEdges(transformedEdges);
   };
-
-  useEffect(() => {
-    initLayoutEngine({
-      nodes: nodes.map(asXY()),
-      links,
-    });
-
-    setTimeout(() => {
-      startLayoutEngine();
-    }, 2000);
-  }, []);
 
   useEffect(() => {
     if (!animation.current) { update.current(); }
 
     return () => window.cancelAnimationFrame(animation.current);
-  }, [isRunning]);
+  }, [isSimulationRunning]);
 
-  return [positionedNodes, positionedEdges];
+  return [positionedNodes, positionedEdges, start];
 };
 
 export default useAutoLayout;

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -96,9 +96,10 @@ const useAutoLayout = (layoutOptions = {}, simulationOptions = {}) => {
   const [positions, scale, updatePositions] = useScaledPositions();
 
   const updateHandler = ({ type, data }) => {
+    console.log('tick');
     switch (type) {
       case 'tick': {
-        updatePositions(data.nodes);
+        updatePositions(data);
 
         nodes.current.map((node) => {
           const originalPosition = get(node, [entityPrimaryKeyProperty, layoutOptions.layout]);
@@ -144,8 +145,8 @@ const useAutoLayout = (layoutOptions = {}, simulationOptions = {}) => {
   const start = useCallback((network) => {
     nodes.current = network.nodes;
     edges.current = network.edges;
-    indexes.current = getIndexes(nodes);
-    links.current = edges.map(asLinks(indexes));
+    indexes.current = getIndexes(nodes.current);
+    links.current = edges.current.map(asLinks(indexes.current));
 
     startSimulation({
       nodes: nodes.current.map(asXY()),

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -22,8 +22,8 @@ const useAutoLayout = (layout, nodes, edges) => {
   const update = useRef(() => {});
   const indexes = getIndexes(nodes);
   const links = edges.map(asLinks(indexes));
-  const [positionedNodes, setPositionedNodes] = useState(nodes);
-  const [positionedEdges, setPositionedEdges] = useState(edges);
+  const [positionedNodes, setPositionedNodes] = useState(nodes.map(asXY()));
+  const [positionedEdges, setPositionedEdges] = useState(links);
 
   const [
     layoutEngineState,
@@ -32,12 +32,7 @@ const useAutoLayout = (layout, nodes, edges) => {
     startLayoutEngine,
   ] = useForceSimulation();
 
-  update.current = () => {
-    if (isRunning) {
-      window.requestAnimationFrame(() => update.current());
-    }
-
-    if (!layoutEngineState.current) { return; }
+  const updatePositions = () => {
     const engineNodes = layoutEngineState.current.nodes;
 
     const mmd = engineNodes.reduce((memo, coords, index) => {
@@ -83,6 +78,16 @@ const useAutoLayout = (layout, nodes, edges) => {
 
     setPositionedNodes(nodePositions);
     setPositionedEdges(edgePositions);
+  };
+
+  update.current = () => {
+    if (isRunning) {
+      window.requestAnimationFrame(() => update.current());
+    }
+
+    if (!layoutEngineState.current) { return; }
+
+    updatePositions();
   };
 
   useEffect(() => {

--- a/src/containers/Interfaces/useAutoLayout.js
+++ b/src/containers/Interfaces/useAutoLayout.js
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+import useForceSimulation from '../../hooks/useForceSimulation';
+
+const LAYOUT = 'ee090c9b-2b70-4648-a6db-328d4ef4dbfe';
+
+const asXY = (layout = LAYOUT) => (node) => ({
+  x: node.attributes[layout].x,
+  y: node.attributes[layout].y,
+});
+
+const getIndexes = (nodes) => nodes
+  .reduce((memo, node, index) => ({ ...memo, [node._uid]: index }), {});
+
+const asLinks = (indexes) => (edge) => ({
+  id: edge.key,
+  source: indexes[edge.ids.from],
+  target: indexes[edge.ids.to],
+});
+
+const useAutoLayout = (layout, nodes, edges) => {
+  const indexes = getIndexes(nodes);
+  const _nodes = nodes.map(asXY());
+  const _links = edges.map(asLinks(indexes));
+
+  const [nodeCoords, setNodeCoords] = useState(
+    nodes.map(asXY()),
+  );
+
+  const handler = (event) => {
+    switch (event.data.type) {
+      case 'tick':
+        setNodeCoords(event.data.nodes);
+        break;
+      case 'end':
+        setNodeCoords(event.data.nodes);
+        break;
+      default:
+    }
+  };
+
+  const [initLayoutEngine] = useForceSimulation(handler);
+
+  useEffect(() => {
+    setTimeout(() => {
+      initLayoutEngine({
+        nodes: _nodes,
+        links: _links,
+      });
+    }, 5000);
+  }, []);
+
+  const start = () => {};
+  const stop = () => {};
+  const running = false;
+
+  const mmd = nodeCoords.reduce((memo, coords, index) => {
+    const minX = memo.minX === null || coords.x < memo.minX ? coords.x : memo.minX;
+    const minY = memo.minY === null || coords.y < memo.minY ? coords.y : memo.minY;
+    const maxX = memo.maxX === null || coords.x > memo.maxX ? coords.x : memo.maxX;
+    const maxY = memo.maxY === null || coords.y > memo.maxY ? coords.y : memo.maxY;
+
+    if (index === nodeCoords.length - 1) {
+      const dX = maxX - minX;
+      const dY = maxY - minY;
+
+      return {
+        dX,
+        dY,
+        minY,
+        minX,
+      };
+    }
+
+    return {
+      minX,
+      minY,
+      maxX,
+      maxY,
+    };
+  }, {
+    minX: null,
+    maxX: null,
+    minY: null,
+    maxY: null,
+  });
+
+  const __nodes = nodes.map((node, index) => ({
+    ...node,
+    attributes: {
+      ...node.attributes,
+      [LAYOUT]: {
+        x: 0.1 + (nodeCoords[index].x - mmd.minX) / mmd.dX * 0.8,
+        y: 0.1 + (nodeCoords[index].y - mmd.minY) / mmd.dY * 0.8,
+      },
+    },
+  }));
+
+  const __edges = edges.map((edge, index) => ({
+    ...edge,
+    from: __nodes[_links[index].source].attributes[LAYOUT],
+    to: __nodes[_links[index].target].attributes[LAYOUT],
+  }));
+
+  console.log(__edges);
+
+  return [__nodes, __edges];
+};
+
+export default useAutoLayout;

--- a/src/containers/Interfaces/useAutoLayout.test.js
+++ b/src/containers/Interfaces/useAutoLayout.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+/* eslint-disable @codaco/spellcheck/spell-checker */
+
+import { transformLayout } from './useAutoLayout';
+
+describe('useAutoLayout()', () => {
+  describe('transformLayout()', () => {
+    const result = transformLayout(
+    );
+
+    expect(result).toEqual({
+    });
+  });
+});

--- a/src/containers/Interfaces/useAutoLayout.test.js
+++ b/src/containers/Interfaces/useAutoLayout.test.js
@@ -3,12 +3,93 @@
 
 import { transformLayout } from './useAutoLayout';
 
+jest.mock('../../hooks/forceSimulation.worker');
+
 describe('useAutoLayout()', () => {
   describe('transformLayout()', () => {
-    const result = transformLayout(
-    );
+    it('returns two arrays', () => {
+      const result = transformLayout(
+        undefined,
+        [],
+        [],
+        [],
+        [],
+      );
 
-    expect(result).toEqual({
+      expect(result).toEqual([[], []]);
+    });
+
+    it('returns unmatched nodes/edges intact', () => {
+      const nodes = [
+        { _uid: 'test_node_1', attributes: { name: 'foo' } },
+        { _uid: 'test_node_2', attributes: { name: 'bar' } },
+      ];
+
+      const edges = [
+        { key: 'test_edge_1', source: 'test_node_1', target: 'test_node_2' },
+      ];
+
+      const result = transformLayout(
+        undefined,
+        nodes,
+        edges,
+        [],
+        [],
+      );
+
+      expect(result).toEqual([
+        nodes,
+        edges,
+      ]);
+    });
+
+    it('returns resolved nodes and edges', () => {
+      const nodes = [
+        { _uid: 'test_node_1', attributes: { name: 'foo' } },
+        { _uid: 'test_node_2', attributes: { name: 'bar' } },
+      ];
+
+      const edges = [
+        { key: 'test_edge_1', ids: { from: 'test_node_1', to: 'test_node_2' } },
+      ];
+
+      const links = [
+        { source: 0, target: 1 },
+      ];
+
+      const positions = [
+        { x: 1, y: 4 },
+        { x: 3, y: 2 },
+      ];
+
+      const result = transformLayout(
+        'layout_var',
+        nodes,
+        edges,
+        positions,
+        links,
+      );
+
+      expect(result).toEqual([
+        [
+          {
+            _uid: 'test_node_1',
+            attributes: { name: 'foo', layout_var: { x: 0.1, y: 0.9 } },
+          },
+          {
+            _uid: 'test_node_2',
+            attributes: { name: 'bar', layout_var: { x: 0.9, y: 0.1 } },
+          },
+        ],
+        [
+          {
+            key: 'test_edge_1',
+            ids: { from: 'test_node_1', to: 'test_node_2' },
+            from: { x: 0.1, y: 0.9 },
+            to: { x: 0.9, y: 0.1 },
+          },
+        ],
+      ]);
     });
   });
 });

--- a/src/containers/Interfaces/useAutoLayout.test.js
+++ b/src/containers/Interfaces/useAutoLayout.test.js
@@ -1,94 +1,53 @@
 /* eslint-env jest */
 /* eslint-disable @codaco/spellcheck/spell-checker */
 
-import { transformLayout } from './useAutoLayout';
+import { translatePositions } from './useAutoLayout';
 
 jest.mock('../../hooks/forceSimulation.worker');
 
 describe('useAutoLayout()', () => {
-  describe('transformLayout()', () => {
-    it('returns two arrays', () => {
-      const result = transformLayout(
-        undefined,
-        [],
-        [],
-        [],
-        [],
-      );
-
-      expect(result).toEqual([[], []]);
-    });
-
-    it('returns unmatched nodes/edges intact', () => {
-      const nodes = [
-        { _uid: 'test_node_1', attributes: { name: 'foo' } },
-        { _uid: 'test_node_2', attributes: { name: 'bar' } },
-      ];
-
-      const edges = [
-        { key: 'test_edge_1', source: 'test_node_1', target: 'test_node_2' },
-      ];
-
-      const result = transformLayout(
-        undefined,
-        nodes,
-        edges,
-        [],
+  describe('translatePositions()', () => {
+    it('returns an object', () => {
+      const result = translatePositions(
         [],
       );
 
       expect(result).toEqual([
-        nodes,
-        edges,
+        {},
+        {
+          minY: null,
+          minX: null,
+          maxY: null,
+          maxX: null,
+          dY: null,
+          dX: null,
+        },
       ]);
     });
 
-    it('returns resolved nodes and edges', () => {
-      const nodes = [
-        { _uid: 'test_node_1', attributes: { name: 'foo' } },
-        { _uid: 'test_node_2', attributes: { name: 'bar' } },
-      ];
-
-      const edges = [
-        { key: 'test_edge_1', ids: { from: 'test_node_1', to: 'test_node_2' } },
-      ];
-
-      const links = [
-        { source: 0, target: 1 },
-      ];
-
+    it('returns positions indexed by id', () => {
       const positions = [
-        { x: 1, y: 4 },
-        { x: 3, y: 2 },
+        { x: 1, y: 4, index: 0, id: 'test_node_1' },
+        { x: 3, y: 2, index: 1, id: 'test_node_2' },
       ];
 
-      const result = transformLayout(
-        'layout_var',
-        nodes,
-        edges,
+      const result = translatePositions(
         positions,
-        links,
       );
 
       expect(result).toEqual([
-        [
-          {
-            _uid: 'test_node_1',
-            attributes: { name: 'foo', layout_var: { x: 0.1, y: 0.9 } },
-          },
-          {
-            _uid: 'test_node_2',
-            attributes: { name: 'bar', layout_var: { x: 0.9, y: 0.1 } },
-          },
-        ],
-        [
-          {
-            key: 'test_edge_1',
-            ids: { from: 'test_node_1', to: 'test_node_2' },
-            from: { x: 0.1, y: 0.9 },
-            to: { x: 0.9, y: 0.1 },
-          },
-        ],
+        {
+          test_node_1: { x: 0.1, y: 0.9 },
+          test_node_2: { x: 0.9, y: 0.1 },
+        },
+        {
+          dX: 2,
+          dY: 2,
+          minY: 2,
+          maxY: 4,
+          minX: 1,
+          maxX: 3,
+        },
       ]);
     });
   });

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -235,6 +235,18 @@ const updateNode = (nodeId, newModelData = {}, newAttributeData = {}) => (dispat
   });
 };
 
+const updateNodes = (nodes = []) => (dispatch) => {
+  nodes.forEach(
+    (nodeId, newModelData = {}, newAttributeData = {}) => {
+      dispatch(updateNode(
+        nodeId,
+        newModelData,
+        newAttributeData,
+      ));
+    },
+  );
+};
+
 const toggleNodeAttributes = (uid, attributes) => (dispatch, getState) => {
   const { activeSessionId } = getState();
 
@@ -445,6 +457,7 @@ const actionCreators = {
   addNode,
   batchAddNodes,
   updateNode,
+  updateNodes,
   removeNode,
   removeNodeFromPrompt,
   updateEgo,

--- a/src/hooks/__mocks__/forceSimulation.worker.js
+++ b/src/hooks/__mocks__/forceSimulation.worker.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -49,12 +49,15 @@ onmessage = function (event) {
       simulation.stop();
       break;
     }
-    // case 'start': {
-    //   console.log('start', { simulation });
-    //   if (!simulation) { return; }
-    //   simulation.restart();
-    //   break;
-    // }
+    case 'update': {
+      if (!simulation) { return; }
+      const newNodes = simulation.nodes();
+      event.data.nodes.forEach((node) => {
+        newNodes[node.index] = node;
+      });
+      simulation.nodes(newNodes);
+      break;
+    }
     default:
   }
 };

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -10,16 +10,15 @@ let simulation;
 
 console.log('new force simulation worker!');
 
-onmessage = function (event) {
-  const {
-    data: {
-      nodes,
-      links,
-    },
-  } = event;
-
-  switch (event.data.type) {
+onmessage = function ({ data }) {
+  switch (data.type) {
     case 'initialize': {
+      const {
+        network: {
+          nodes,
+          links,
+        },
+      } = data;
       console.debug('worker:initialize');
       simulation = forceSimulation(nodes)
         .force('charge', forceManyBody())
@@ -51,11 +50,17 @@ onmessage = function (event) {
     }
     case 'update': {
       if (!simulation) { return; }
-      const newNodes = simulation.nodes();
-      event.data.nodes.forEach((node) => {
-        newNodes[node.index] = node;
-      });
-      simulation.nodes(newNodes);
+      const {
+        network: {
+          nodes,
+          links,
+        },
+      } = data;
+
+      simulation
+        .nodes(nodes)
+        .alpha(1)
+        .force('link', forceLink(links).distance(10).strength(1));
       break;
     }
     default:

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -18,9 +18,10 @@ onmessage = function (event) {
 
   switch (event.data.type) {
     case 'initialize': {
+      console.log({ links });
       simulation = forceSimulation(nodes)
         .force('charge', forceManyBody())
-        .force('link', forceLink(links).distance(20).strength(1))
+        .force('link', forceLink(links).distance(10).strength(1))
         .force('x', forceX())
         .force('y', forceY())
         .stop();

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -1,0 +1,39 @@
+import {
+  forceSimulation,
+  forceX,
+  forceY,
+  forceManyBody,
+  forceLink,
+} from 'd3-force';
+
+onmessage = function (event) {
+  const {
+    data: {
+      nodes,
+      links,
+    },
+  } = event;
+
+  const simulation = forceSimulation(nodes)
+    .force('charge', forceManyBody())
+    .force('link', forceLink(links).distance(20).strength(1))
+    .force('x', forceX())
+    .force('y', forceY())
+    .stop();
+
+  for (let i = 0, n = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay())); i < n; ++i) {
+    postMessage({
+      type: 'tick',
+      progress: i / n,
+      nodes,
+      links,
+    });
+    simulation.tick();
+  }
+
+  postMessage({
+    type: 'end',
+    nodes,
+    links,
+  });
+};

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -18,13 +18,11 @@ onmessage = function (event) {
 
   switch (event.data.type) {
     case 'initialize': {
-      console.log({ links });
       simulation = forceSimulation(nodes)
         .force('charge', forceManyBody())
         .force('link', forceLink(links).distance(10).strength(1))
         .force('x', forceX())
-        .force('y', forceY())
-        .stop();
+        .force('y', forceY());
 
       simulation.on('tick', () => {
         postMessage({
@@ -46,12 +44,12 @@ onmessage = function (event) {
       simulation.stop();
       break;
     }
-    case 'start': {
-      console.log('start', { simulation });
-      if (!simulation) { return; }
-      simulation.restart();
-      break;
-    }
+    // case 'start': {
+    //   console.log('start', { simulation });
+    //   if (!simulation) { return; }
+    //   simulation.restart();
+    //   break;
+    // }
     default:
   }
 };

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -20,6 +20,7 @@ onmessage = function (event) {
 
   switch (event.data.type) {
     case 'initialize': {
+      console.debug('worker:initialize');
       simulation = forceSimulation(nodes)
         .force('charge', forceManyBody())
         .force('link', forceLink(links).distance(10).strength(1))
@@ -27,6 +28,7 @@ onmessage = function (event) {
         .force('y', forceY());
 
       simulation.on('tick', () => {
+        console.debug('worker:tick');
         postMessage({
           type: 'tick',
           nodes: simulation.nodes(),
@@ -34,6 +36,7 @@ onmessage = function (event) {
       });
 
       simulation.on('end', () => {
+        console.debug('worker:end');
         postMessage({
           type: 'end',
           nodes: simulation.nodes(),

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -8,6 +8,8 @@ import {
 
 let simulation;
 
+console.log('new force simulation worker!');
+
 onmessage = function (event) {
   const {
     data: {

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -17,13 +17,20 @@ onmessage = function (event) {
   } = event;
 
   switch (event.data.type) {
-    case 'init': {
+    case 'initialize': {
       simulation = forceSimulation(nodes)
         .force('charge', forceManyBody())
         .force('link', forceLink(links).distance(20).strength(1))
         .force('x', forceX())
         .force('y', forceY())
         .stop();
+
+      simulation.on('tick', () => {
+        postMessage({
+          type: 'tick',
+          nodes: simulation.nodes(),
+        });
+      });
 
       simulation.on('end', () => {
         postMessage({
@@ -33,12 +40,15 @@ onmessage = function (event) {
       });
       break;
     }
-    case 'tick': {
-      simulation.tick();
-      postMessage({
-        type: 'tick',
-        nodes: simulation.nodes(),
-      });
+    case 'stop': {
+      if (!simulation) { return; }
+      simulation.stop();
+      break;
+    }
+    case 'start': {
+      console.log('start', { simulation });
+      if (!simulation) { return; }
+      simulation.restart();
       break;
     }
     default:

--- a/src/hooks/forceSimulation.worker.js
+++ b/src/hooks/forceSimulation.worker.js
@@ -6,6 +6,8 @@ import {
   forceLink,
 } from 'd3-force';
 
+let simulation;
+
 onmessage = function (event) {
   const {
     data: {
@@ -14,26 +16,31 @@ onmessage = function (event) {
     },
   } = event;
 
-  const simulation = forceSimulation(nodes)
-    .force('charge', forceManyBody())
-    .force('link', forceLink(links).distance(20).strength(1))
-    .force('x', forceX())
-    .force('y', forceY())
-    .stop();
+  switch (event.data.type) {
+    case 'init': {
+      simulation = forceSimulation(nodes)
+        .force('charge', forceManyBody())
+        .force('link', forceLink(links).distance(20).strength(1))
+        .force('x', forceX())
+        .force('y', forceY())
+        .stop();
 
-  for (let i = 0, n = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay())); i < n; ++i) {
-    postMessage({
-      type: 'tick',
-      progress: i / n,
-      nodes,
-      links,
-    });
-    simulation.tick();
+      simulation.on('end', () => {
+        postMessage({
+          type: 'end',
+          nodes: simulation.nodes(),
+        });
+      });
+      break;
+    }
+    case 'tick': {
+      simulation.tick();
+      postMessage({
+        type: 'tick',
+        nodes: simulation.nodes(),
+      });
+      break;
+    }
+    default:
   }
-
-  postMessage({
-    type: 'end',
-    nodes,
-    links,
-  });
 };

--- a/src/hooks/useDropTarget.js
+++ b/src/hooks/useDropTarget.js
@@ -1,0 +1,66 @@
+/* eslint-disable react/no-find-dom-node, react/jsx-props-no-spreading */
+
+import { useRef, useEffect } from 'react';
+import { actionCreators as actions } from '../behaviours/DragAndDrop/reducer';
+import getAbsoluteBoundingRect from '../utils/getAbsoluteBoundingRect';
+import store from '../behaviours/DragAndDrop/store';
+
+const maxFramesPerSecond = 10;
+
+const useDropTarget = (
+  ref,
+  {
+    id,
+    onDrop,
+    onDrag,
+    onDragEnd,
+    accepts = () => false,
+    meta = () => ({}),
+  },
+) => {
+  const raf = useRef();
+
+  const update = () => {
+    if (!ref.current) { return; }
+
+    const boundingClientRect = getAbsoluteBoundingRect(ref.current);
+
+    console.log(' update ');
+
+    store.dispatch(
+      actions.upsertTarget({
+        id,
+        onDrop,
+        onDrag,
+        onDragEnd,
+        accepts,
+        meta: meta(),
+        width: boundingClientRect.width,
+        height: boundingClientRect.height,
+        y: boundingClientRect.top,
+        x: boundingClientRect.left,
+      }),
+    );
+
+    raf.current = requestAnimationFrame(update);
+  };
+
+  const removeTarget = () => {
+    store.dispatch(
+      actions.removeTarget(id),
+    );
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      update();
+    }
+
+    return () => {
+      removeTarget();
+      cancelAnimationFrame(raf);
+    };
+  }, [ref.current]);
+};
+
+export default useDropTarget;

--- a/src/hooks/useDropTarget.js
+++ b/src/hooks/useDropTarget.js
@@ -19,13 +19,14 @@ const useDropTarget = (
   },
 ) => {
   const raf = useRef();
+  const update = useRef();
 
-  const update = () => {
+  update.current = () => {
     if (!ref.current) { return; }
 
-    const boundingClientRect = getAbsoluteBoundingRect(ref.current);
+    // console.log('update', funcId);
 
-    console.log(' update ');
+    const boundingClientRect = getAbsoluteBoundingRect(ref.current);
 
     store.dispatch(
       actions.upsertTarget({
@@ -42,7 +43,7 @@ const useDropTarget = (
       }),
     );
 
-    raf.current = requestAnimationFrame(update);
+    raf.current = requestAnimationFrame(() => update.current());
   };
 
   const removeTarget = () => {
@@ -53,7 +54,7 @@ const useDropTarget = (
 
   useEffect(() => {
     if (ref.current) {
-      update();
+      update.current();
     }
 
     return () => {

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -12,6 +12,7 @@ const useForceSimulation = () => {
   const [isRunning, setIsRunning] = useState(false);
 
   const start = useCallback(({ nodes, links }) => {
+    worker.current = new ForceSimulationWorker();
     worker.current.postMessage({
       type: 'initialize',
       nodes,

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -1,38 +1,23 @@
 import {
   useRef,
   useCallback,
-  useEffect,
   useState,
 } from 'react';
 import ForceSimulationWorker from './forceSimulation.worker';
 
 const useForceSimulation = () => {
-  const worker = useRef(new ForceSimulationWorker());
+  const worker = useRef(null);
   const state = useRef(null);
   const [isRunning, setIsRunning] = useState(false);
 
   const start = useCallback(({ nodes, links }) => {
     worker.current = new ForceSimulationWorker();
-    worker.current.postMessage({
-      type: 'initialize',
-      nodes,
-      links,
-    });
 
     state.current = {
       links,
       nodes,
     };
 
-    setIsRunning(true);
-  });
-
-  const stop = useCallback(() => {
-    worker.current.postMessage({ type: 'stop' });
-    setIsRunning(false);
-  });
-
-  useEffect(() => {
     worker.current.onmessage = (event) => {
       switch (event.data.type) {
         case 'tick':
@@ -45,7 +30,20 @@ const useForceSimulation = () => {
         default:
       }
     };
-  }, []);
+
+    worker.current.postMessage({
+      type: 'initialize',
+      nodes,
+      links,
+    });
+
+    setIsRunning(true);
+  });
+
+  const stop = useCallback(() => {
+    worker.current.postMessage({ type: 'stop' });
+    setIsRunning(false);
+  });
 
   return [state, isRunning, start, stop];
 };

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -1,0 +1,31 @@
+import { useRef, useCallback, useEffect } from 'react';
+import ForceSimulationWorker from './forceSimulation.worker.js';
+
+// example listener:
+// function (event) {
+//   switch (event.data.type) {
+//     case "tick": return ticked(event.data);
+//     case "end": return ended(event.data);
+//   }
+// };
+
+const useForceSimulation = (listener) => {
+  const worker = useRef(new ForceSimulationWorker());
+
+  const init = useCallback(({ nodes, links }) => {
+    worker.current.postMessage({
+      nodes,
+      links,
+    });
+  });
+
+  useEffect(() => {
+    worker.current.onmessage = (event) => {
+      listener(event);
+    };
+  }, []);
+
+  return [init];
+};
+
+export default useForceSimulation;

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -48,7 +48,12 @@ const useForceSimulation = (listener) => {
     setIsRunning(false);
   });
 
-  return [state, isRunning, start, stop];
+  const update = useCallback((nodes = []) => {
+    if (!worker.current) { return; }
+    worker.current.postMessage({ type: 'update', nodes });
+  });
+
+  return [state, isRunning, start, stop, update];
 };
 
 export default useForceSimulation;

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -14,11 +14,11 @@ const useForceSimulation = (listener) => {
   const state = useRef(null);
   const [isRunning, setIsRunning] = useState(false);
 
-  const init = useCallback(({ nodes, edges }) => {
+  const init = useCallback(({ nodes, links }) => {
     worker.current.postMessage({
       type: 'initialize',
       nodes,
-      edges,
+      links,
     });
   });
 

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -11,6 +11,7 @@ const useForceSimulation = () => {
   const [isRunning, setIsRunning] = useState(false);
 
   const start = useCallback(({ nodes, links }) => {
+    console.log('intialize worker');
     worker.current = new ForceSimulationWorker();
 
     state.current = {
@@ -24,7 +25,6 @@ const useForceSimulation = () => {
           state.current.nodes = event.data.nodes;
           break;
         case 'end':
-          console.log({ finish: state.current });
           setIsRunning(false);
           break;
         default:
@@ -41,7 +41,9 @@ const useForceSimulation = () => {
   });
 
   const stop = useCallback(() => {
+    if (!worker.current) { return; }
     worker.current.postMessage({ type: 'stop' });
+    worker.current = null;
     setIsRunning(false);
   });
 

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -5,7 +5,7 @@ import {
 } from 'react';
 import ForceSimulationWorker from './forceSimulation.worker';
 
-const useForceSimulation = () => {
+const useForceSimulation = (listener) => {
   const worker = useRef(null);
   const state = useRef(null);
   const [isRunning, setIsRunning] = useState(false);
@@ -23,6 +23,7 @@ const useForceSimulation = () => {
       switch (event.data.type) {
         case 'tick':
           state.current.nodes = event.data.nodes;
+          listener({ type: 'tick', data: event.data.nodes });
           break;
         case 'end':
           setIsRunning(false);

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -1,29 +1,28 @@
-import { useRef, useCallback, useEffect, useState } from 'react';
+import {
+  useRef,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import ForceSimulationWorker from './forceSimulation.worker';
 
-// example listener:
-// function (event) {
-//   switch (event.data.type) {
-//     case "tick": return ticked(event.data);
-//     case "end": return ended(event.data);
-//   }
-// };
-
-const useForceSimulation = (listener) => {
+const useForceSimulation = () => {
   const worker = useRef(new ForceSimulationWorker());
   const state = useRef(null);
   const [isRunning, setIsRunning] = useState(false);
 
-  const init = useCallback(({ nodes, links }) => {
+  const start = useCallback(({ nodes, links }) => {
     worker.current.postMessage({
       type: 'initialize',
       nodes,
       links,
     });
-  });
 
-  const start = useCallback(() => {
-    worker.current.postMessage({ type: 'start' });
+    state.current = {
+      links,
+      nodes,
+    };
+
     setIsRunning(true);
   });
 
@@ -34,12 +33,12 @@ const useForceSimulation = (listener) => {
 
   useEffect(() => {
     worker.current.onmessage = (event) => {
-      // listener(event);
       switch (event.data.type) {
         case 'tick':
-          state.current = event.data;
+          state.current.nodes = event.data.nodes;
           break;
         case 'end':
+          console.log({ finish: state.current });
           setIsRunning(false);
           break;
         default:
@@ -47,7 +46,7 @@ const useForceSimulation = (listener) => {
     };
   }, []);
 
-  return [state, isRunning, init, start, stop];
+  return [state, isRunning, start, stop];
 };
 
 export default useForceSimulation;

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -22,7 +22,7 @@ const useForceSimulation = (listener) => {
     worker.current.onmessage = (event) => {
       switch (event.data.type) {
         case 'tick':
-          state.current.nodes = event.data.nodes;
+          state.current.positions = event.data.nodes;
           listener({ type: 'tick', data: event.data.nodes });
           break;
         case 'end':

--- a/src/hooks/useForceSimulation.js
+++ b/src/hooks/useForceSimulation.js
@@ -34,8 +34,10 @@ const useForceSimulation = (listener) => {
 
     worker.current.postMessage({
       type: 'initialize',
-      nodes,
-      links,
+      network: {
+        nodes,
+        links,
+      },
     });
 
     setIsRunning(true);
@@ -48,9 +50,21 @@ const useForceSimulation = (listener) => {
     setIsRunning(false);
   });
 
-  const update = useCallback((nodes = []) => {
+  const update = useCallback(({ nodes, links }) => {
     if (!worker.current) { return; }
-    worker.current.postMessage({ type: 'update', nodes });
+
+    state.current = {
+      links,
+      nodes,
+    };
+
+    worker.current.postMessage({
+      type: 'update',
+      network: {
+        nodes,
+        links,
+      },
+    });
   });
 
   return [state, isRunning, start, stop, update];

--- a/src/hooks/useSize.js
+++ b/src/hooks/useSize.js
@@ -1,0 +1,46 @@
+/* eslint-disable react/no-find-dom-node */
+
+import { useRef, useEffect } from 'react';
+import { isEqual } from 'lodash';
+import getAbsoluteBoundingRect from '../utils/getAbsoluteBoundingRect';
+
+const initialState = {
+  width: 0,
+  height: 0,
+  y: 0,
+  x: 0,
+};
+
+const useSize = (ref) => {
+  const state = useRef(initialState);
+  const raf = useRef();
+
+  const trackSize = () => {
+    const boundingClientRect = getAbsoluteBoundingRect(ref.current);
+
+    const nextState = {
+      width: boundingClientRect.width,
+      height: boundingClientRect.height,
+      y: boundingClientRect.top,
+      x: boundingClientRect.left,
+    };
+
+    if (!isEqual(state.current, nextState)) {
+      state.current = nextState;
+    }
+
+    raf.current = requestAnimationFrame(trackSize);
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      trackSize();
+    }
+
+    return () => cancelAnimationFrame(raf.current);
+  }, [ref.current]);
+
+  return state;
+};
+
+export default useSize;

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -70,7 +70,7 @@ const edgeCoords = (edge, { nodes, layout }) => {
   const from = nodes.find((n) => n[entityPrimaryKeyProperty] === edge.from);
   const to = nodes.find((n) => n[entityPrimaryKeyProperty] === edge.to);
 
-  if (!from || !to) { return { from: null, to: null }; }
+  if (!from || !to) { return null; }
 
   return {
     key: `${edge.from}_${edge.type}_${edge.to}`,
@@ -81,11 +81,20 @@ const edgeCoords = (edge, { nodes, layout }) => {
   };
 };
 
-export const edgesToCoords = (edges, { nodes, layout }) => edges.map(
-  (edge) => edgeCoords(
-    edge,
-    { nodes, layout },
-  ),
+export const edgesToCoords = (edges, { nodes, layout }) => (
+  edges.reduce(
+    (acc, edge) => {
+      const edgeWithCoords = edgeCoords(
+        edge,
+        { nodes, layout },
+      );
+
+      if (!edgeWithCoords) { return acc; }
+
+      return [...acc, edgeWithCoords];
+    },
+    [],
+  )
 );
 
 /**

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -74,6 +74,7 @@ const edgeCoords = (edge, { nodes, layout }) => {
 
   return {
     key: `${edge.from}_${edge.type}_${edge.to}`,
+    ids: { from: edge.from, to: edge.to },
     type: edge.type,
     from: from[entityAttributesProperty][layout],
     to: to[entityAttributesProperty][layout],


### PR DESCRIPTION
The aim of the feature is to have a toggle which when activated would enable a ‘spring embedder’ physics based layout of the nodes on the sociogram.

This implementation uses this engine: https://github.com/d3/d3-force. It is primarily intended for d3, but is written in such a way that it can be used without it. `cola.js` was also considered but the documentation wasn't up to scratch.

This attempt to build the feature hit a dead-end mainly due to "zoom" controls being a requirement of this feature.

## Requirements
- Force direction should be togglable.
- Nodes should still be draggable, and the layout will run continuously whilst the layout is active.

## Implementation

- Layout engine runs using a web worker.
- `useForceSimulation()` hook provides interface to worker/d3-force, current network state is managed as a React ref to prevent render thrashing. Consumer can read values as needed.
- `useAutoLayout()` hook translates between d3-force format (uses x/y co-ordinates to represent positions) and the Interviewer format (uses 0-1 decimal x/y to represent positions). This data is also managed as a ref.
- Rendering uses requestAnimationFrame() to draw data from `useAutoLayout()`.

## Post mortem

- Found it more perfomant for the worker to send simulation all frames to the client, rather than have the client request them as needed. Any extra frames can simply be ignored at the client end.
- When dragging nodes with auto layout active can experience "fighting the layout". I didn't get to the bottom of why this happened, perhaps an extra rendering loop between sending and calculating the change?
- Not convinced useAutoLayout hook should exist, or at least be in charge of translating positions - instead this could maybe simply be a function: `const transformedNodes = blendLayouts(nodes = [], forceSimulationPositions = [], toggle = true/false);`
- `useAutoLayout()` uses scaling to convert between co-ordinate types. This can change depending on the bounds of the d3-force positions. When dragging a node the bounds may change either smaller or larger, changing the zoom and giving an uncomfortable user experience. My recommendation here would be to use fixed zoom, with user controls.

## Things to solve

- [ ] What is the best way to maintain parity between absolute positions used by d3-force, and relative positions used by Sociogram. One suggestion might be to use static zoom values which are controlled by the user.
- [ ] How to render efficiently without "fighting the layout"? Should position rendering be managed by react or should the auto layout directly manipulate dom elements? Does this need a rethink of the drag and drop libraries?
