### PR TITLE
correct stale documentation links

### DIFF
--- a/src/containers/StartScreen/ServerAddressForm.js
+++ b/src/containers/StartScreen/ServerAddressForm.js
@@ -107,7 +107,7 @@ const ServerAddressForm = ({
       <p>
         Visit our
         {' '}
-        <ExternalLink href="https://documentation.networkcanvas.com/reference/key-concepts/pairing/">documentation article</ExternalLink>
+        <ExternalLink href="https://documentation.networkcanvas.com/key-concepts/pairing/">documentation article</ExternalLink>
         {' '}
         on pairing to learn more.
       </p>

--- a/src/containers/StartScreen/ServerSection.js
+++ b/src/containers/StartScreen/ServerSection.js
@@ -131,7 +131,7 @@ const ServerSection = () => {
             )}
           </div>
           <div className="content-area__buttons">
-            <Button color="mustard--dark" disabled={!onlineStatus} onClick={() => openExternalLink('https://documentation.networkcanvas.com/reference/key-concepts/pairing')}>View Pairing Documentation</Button>
+            <Button color="mustard--dark" disabled={!onlineStatus} onClick={() => openExternalLink('https://documentation.networkcanvas.com/key-concepts/pairing')}>View Pairing Documentation</Button>
             { !pairedServer ? (
               <Button disabled={!onlineStatus} color="platinum" onClick={() => setShowServerAddressForm(true)}>Provide manual connection details...</Button>
             )


### PR DESCRIPTION
This updates a couple of broken documentation links.

I do still have an error when attempting to install the Sample Protocol, so still looking at that if anyone has thoughts.
`RequestError: Error: certificate has expired`