### PR TITLE
type correction for rosters too

### DIFF
--- a/src/containers/withExternalData.js
+++ b/src/containers/withExternalData.js
@@ -231,6 +231,17 @@ const withTypeReplacement = (nodeList, protocolCodebook, stageSubject) => {
   return getNodeListUsingTypes(nodeList, protocolCodebook, stageSubject, codebookAttributeTypes);
 };
 
+export const getVariableTypeReplacements = (
+  sourceFile, uuidData, protocolCodebook, stageSubject,
+) => {
+  const fileExtension = (fileName) => fileName.split('.').pop();
+  const fileType = fileExtension(sourceFile) === 'csv' ? 'csv' : 'json';
+  if (fileType === 'csv') {
+    return withTypeReplacement(uuidData, protocolCodebook, stageSubject);
+  }
+  return uuidData;
+};
+
 /**
  * Creates a higher order component which can be used to load data from network assets in
  * the assetsManifest onto a component.
@@ -287,14 +298,9 @@ const withExternalData = (sourceProperty, dataProperty) => compose(
         .then((externalData) => (
           withVariableUUIDReplacement(externalData.nodes, protocolCodebook, stageSubject)
         ))
-        .then((uuidData) => {
-          const fileExtension = (fileName) => fileName.split('.').pop();
-          const fileType = fileExtension(sourceFile) === 'csv' ? 'csv' : 'json';
-          if (fileType === 'csv') {
-            return withTypeReplacement(uuidData, protocolCodebook, stageSubject);
-          }
-          return uuidData;
-        })
+        .then((uuidData) => getVariableTypeReplacements(
+          sourceFile, uuidData, protocolCodebook, stageSubject,
+        ))
         .then((nodes) => {
           setExternalDataIsLoading(false);
           setExternalData({ nodes });

--- a/src/hooks/useExternalData.js
+++ b/src/hooks/useExternalData.js
@@ -6,6 +6,7 @@ import objectHash from 'object-hash';
 import { mapValues, mapKeys } from 'lodash';
 import loadExternalData from '../utils/loadExternalData';
 import getParentKeyByNameValue from '../utils/getParentKeyByNameValue';
+import { getVariableTypeReplacements } from '../containers/withExternalData';
 import { entityAttributesProperty, entityPrimaryKeyProperty } from '../ducks/modules/network';
 
 const getSessionMeta = (state) => {
@@ -80,6 +81,9 @@ const useExternalData = (dataSource, subject) => {
 
     loadExternalData(protocolUID, sourceFile, type)
       .then(({ nodes }) => Promise.all(nodes.map(variableUUIDReplacer)))
+      .then((uuidData) => getVariableTypeReplacements(
+        sourceFile, uuidData, protocolCodebook, subject,
+      ))
       .then((formattedData) => setExternalData(formattedData))
       .then(() => updateStatus({ isLoading: false }))
       .catch((e) => updateStatus({ isLoading: false, error: e }));


### PR DESCRIPTION
Somehow we applied the type correction for cvs data to name generators, and not large and small rosters. This adds it in for rosters as well.