### PR TITLE
leave-full-screen event was firing when app lost focus on linux. chec…

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -109,10 +109,15 @@ const App = ({
         win.setFullScreen(!!startFullScreen);
 
         win.on('enter-full-screen', () => {
+          if (startFullScreen) { return; }
           setStartFullScreen(true);
         });
 
+        // For some reason, this fires when the window loses focus (when
+        // switching workspaces) on linux.
         win.on('leave-full-screen', () => {
+          if (!startFullScreen) { return; }
+
           setStartFullScreen(false);
         });
       }
@@ -123,7 +128,7 @@ const App = ({
         win.removeAllListeners();
       }
     };
-  }, [win]);
+  }, [win, startFullScreen, setStartFullScreen]);
 
   setFontSize();
 


### PR DESCRIPTION
…k if event needs to be dispatched rather than doing so every time