### PR TITLE
Fix/other dialog markdown

### DIFF
--- a/src/containers/CategoricalList/OtherVariableForm.js
+++ b/src/containers/CategoricalList/OtherVariableForm.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { Button, Node } from '@codaco/ui';
+import { MarkdownLabel } from '@codaco/ui/lib/components/Fields';
 import Field from '../Field';
 
 const stopClickPropagation = (e) => e.stopPropagation();
@@ -20,7 +21,9 @@ const OtherVariableForm = ({
           <Node label={label} color={color} />
         </div>
         <div className="other-variable-form__content-right">
-          <h4>{otherVariablePrompt}</h4>
+          <h4>
+            <MarkdownLabel inline label={otherVariablePrompt} />
+          </h4>
           <Field
             label=""
             placeholder="Enter your response here..."

--- a/src/containers/Server/PairingCodeDialog.js
+++ b/src/containers/Server/PairingCodeDialog.js
@@ -117,7 +117,7 @@ const PairingCodeDialog = (props) => {
   }, [server]);
 
   return (
-    <motion.div>
+    <motion.div className="pairing-content">
       {
         loading
           ? (

--- a/src/styles/components/_other-variable-form.scss
+++ b/src/styles/components/_other-variable-form.scss
@@ -1,6 +1,7 @@
 .other-variable-form {
   height: auto;
   padding: 2rem 0;
+  flex: 1 1;
 
   &__content {
     display: flex;

--- a/src/styles/containers/StartScreen/_pairing-form.scss
+++ b/src/styles/containers/StartScreen/_pairing-form.scss
@@ -1,3 +1,7 @@
+.pairing-content {
+  flex: 1 1;
+}
+
 .pairing-form {
   margin-bottom: unit(4);
 


### PR DESCRIPTION
This makes sure markdown is accepted in Categorical's "other" dialog label. It also fixes the formatting for the other dialog overlay, and the pairing dialog as well. Fixes #1153.