### PR TITLE
fix/ action button still clickable after max reached

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@babel/preset-react": "7.10.1",
         "@codaco/eslint-plugin-spellcheck": "0.0.14",
         "@codaco/shared-consts": "~0.0.1-alpha.3",
-        "@codaco/ui": "~5.8.3",
+        "@codaco/ui": "~5.8.5",
         "@electron/notarize": "~1.2.3",
         "@faker-js/faker": "~6.0.0-alpha.5",
         "@zippytech/sorty": "^2.0.0",
@@ -1918,9 +1918,9 @@
       "dev": true
     },
     "node_modules/@codaco/ui": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/@codaco/ui/-/ui-5.8.3.tgz",
-      "integrity": "sha512-rRb9cwpO5STD8gcdyPyNzloHpKOU1zOcS7o/wnx5jpBlpVaX9bWuNQ2k2/p5gNFj+EnuXslnNcVFI8k4Om35dQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@codaco/ui/-/ui-5.8.5.tgz",
+      "integrity": "sha512-RyUjHE7Rscfk0RbYDbSUY0GUmWMz0aKbB3AITPBNKLqpJzLekpNkDZmQNn5w/X+pwbgJClWaZrDCQRLWbBeOSg==",
       "dev": true,
       "dependencies": {
         "@material-ui/core": "^4.11.3",
@@ -37749,9 +37749,9 @@
       "dev": true
     },
     "@codaco/ui": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/@codaco/ui/-/ui-5.8.3.tgz",
-      "integrity": "sha512-rRb9cwpO5STD8gcdyPyNzloHpKOU1zOcS7o/wnx5jpBlpVaX9bWuNQ2k2/p5gNFj+EnuXslnNcVFI8k4Om35dQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@codaco/ui/-/ui-5.8.5.tgz",
+      "integrity": "sha512-RyUjHE7Rscfk0RbYDbSUY0GUmWMz0aKbB3AITPBNKLqpJzLekpNkDZmQNn5w/X+pwbgJClWaZrDCQRLWbBeOSg==",
       "dev": true,
       "requires": {
         "@material-ui/core": "^4.11.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-react": "7.10.1",
     "@codaco/eslint-plugin-spellcheck": "0.0.14",
     "@codaco/shared-consts": "~0.0.1-alpha.3",
-    "@codaco/ui": "~5.8.3",
+    "@codaco/ui": "~5.8.5",
     "@electron/notarize": "~1.2.3",
     "@faker-js/faker": "~6.0.0-alpha.5",
     "@zippytech/sorty": "^2.0.0",

--- a/src/containers/NodeForm.js
+++ b/src/containers/NodeForm.js
@@ -97,7 +97,7 @@ const NodeForm = (props) => {
         >
           <ActionButton
             disabled={disabled}
-            onClick={() => setShow(true)}
+            onClick={() => !disabled && setShow(true)}
             icon={icon}
             title={`Add ${nodeType}...`}
           />

--- a/src/containers/NodeForm.js
+++ b/src/containers/NodeForm.js
@@ -97,7 +97,7 @@ const NodeForm = (props) => {
         >
           <ActionButton
             disabled={disabled}
-            onClick={() => !disabled && setShow(true)}
+            onClick={() => setShow(true)}
             icon={icon}
             title={`Add ${nodeType}...`}
           />

--- a/src/containers/QuickNodeForm.js
+++ b/src/containers/QuickNodeForm.js
@@ -185,7 +185,7 @@ const QuickAddForm = ({
           >
             <ActionButton
               disabled={disabled}
-              onClick={() => !disabled && setShowForm(true)}
+              onClick={() => setShowForm(true)}
               icon={icon}
               title={`Add ${nodeType}...`}
             />


### PR DESCRIPTION
Fixes a bug where additional nodes could be added on name generators with forms after the max nodes had been added.

- This was due to the button still being clickable even if it appeared disabled.

- Decided to fix in codaco/ui instead of handling this here. Implemented in https://github.com/complexdatacollective/Network-Canvas-UI/pull/208 .
- This PR updates the ui package to 5.8.5 which fixes this issue, and removes the checks within the onclick function for disabled as they are no longer needed.
