### PR TITLE
attempt to fix csv writing on cordova by replacing streaming

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget android-versionCode="6388" id="org.codaco.NetworkCanvasInterviewer6" ios-CFBundleIdentifier="org.codaco.networkCanvasInterviewerBusiness" ios-CFBundleVersion="6388" version="6.5.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="6388" id="org.codaco.NetworkCanvasInterviewer6" ios-CFBundleIdentifier="org.codaco.networkCanvasInterviewerBusiness" ios-CFBundleVersion="6388" version="6.5.1"
+  xmlns="http://www.w3.org/ns/widgets"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>Network Canvas Interviewer</name>
   <description>
         A tool for conducting Network Canvas Interviews.
@@ -7,7 +10,7 @@
   <author email="developers@coda.co" href="http://coda.co">
         Complex Data Collective
   </author>
-  <content src="index.html"/>
+  <content src="http://192.168.1.210:3000/"/>
   <access origin="*"/>
   <access origin="cdvfile://*"/>
   <allow-intent href="http://*/*"/>

--- a/config/nc-dev-utils.js
+++ b/config/nc-dev-utils.js
@@ -75,9 +75,7 @@ const devServerContentBase = () => {
 };
 
 // Webpack default is 'web'. To get electron working with dev server, use 'electron-renderer'.
-// const reactBundleTarget = () => (isTargetingElectron ? 'electron-renderer' : 'web');
-
-const reactBundleTarget = () => 'web';
+const reactBundleTarget = () => (isTargetingElectron ? 'electron-renderer' : 'web');
 
 module.exports = {
   cleanDevUrlFile,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "d3-force": "~3.0.0",
         "dmg-builder": "~23.6.0",
         "electron-devtools-installer": "^3.0.0",
+        "papaparse": "~5.4.1",
         "xcode": "~3.0.1",
         "zeroconf": "^0.1.4"
       },
@@ -24278,6 +24279,11 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/parallel-transform": {
       "version": "1.2.0",
@@ -55016,6 +55022,11 @@
     },
     "pako": {
       "version": "1.0.11"
+    },
+    "papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "parallel-transform": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "d3-force": "~3.0.0",
     "dmg-builder": "~23.6.0",
     "electron-devtools-installer": "^3.0.0",
+    "papaparse": "~5.4.1",
     "xcode": "~3.0.1",
     "zeroconf": "^0.1.4"
   },


### PR DESCRIPTION
This is an attempt to fix duplicate headers in the csv export.

It replaces the node stream functionality with simple string writing, and uses papa parse instead of constructing the csv manually.

It doesn't seem to work!