### PR TITLE
Fix/ sort by categorical variables

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget android-versionCode="6415" id="org.codaco.NetworkCanvasInterviewer6" ios-CFBundleIdentifier="org.codaco.networkCanvasInterviewerBusiness" ios-CFBundleVersion="6415" version="6.5.2"
+<widget android-versionCode="6415" id="org.codaco.NetworkCanvasInterviewer6" ios-CFBundleIdentifier="org.codaco.networkCanvasInterviewerBusiness" ios-CFBundleVersion="6415" version="6.5.3"
   xmlns="http://www.w3.org/ns/widgets"
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:cdv="http://cordova.apache.org/ns/1.0">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "network-canvas-interviewer",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "network-canvas-interviewer",
-      "version": "6.5.2",
+      "version": "6.5.3",
       "dependencies": {
         "@babel/runtime": "7.10.1",
         "@xmldom/xmldom": "~0.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-canvas-interviewer",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "productName": "Network Canvas Interviewer",
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective",

--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-canvas-interviewer",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "productName": "Network Canvas Interviewer",
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective",

--- a/src/utils/__tests__/createSorter.test.js
+++ b/src/utils/__tests__/createSorter.test.js
@@ -320,6 +320,117 @@ describe('Types', () => {
   });
 });
 
+describe('Categorical sorting', () => {
+  it('sorts items based on categorical values', () => {
+    const mockItems = [
+      {
+        category: ['cow'],
+        name: 'alice',
+      },
+      {
+        category: ['duck'],
+        name: 'bob',
+      },
+      {
+        category: ['lizard'],
+        name: 'charlie',
+      },
+      {
+        category: ['cow'],
+        name: 'david',
+      },
+    ];
+
+    const sorter = createSorter([
+      {
+        property: 'category',
+        type: 'categorical',
+        hierarchy: ['duck', 'lizard', 'cow'],
+      },
+      {
+        property: 'name',
+        type: 'string',
+        direction: 'asc',
+      },
+    ]);
+
+    const result = sorter(mockItems).map((item) => item.name);
+    expect(result).toEqual(['alice', 'david', 'charlie', 'bob']);
+  });
+
+  it('handles items with multiple categories', () => {
+    const mockItems = [
+      {
+        category: ['duck', 'lizard'],
+        name: 'alice',
+      },
+      {
+        category: ['cow', 'duck'],
+        name: 'bob',
+      },
+      {
+        category: ['cow'],
+        name: 'charlie',
+      },
+      {
+        category: ['lizard'],
+        name: 'david',
+      },
+    ];
+
+    const sorter = createSorter([
+      {
+        property: 'category',
+        type: 'categorical',
+        hierarchy: ['cow', 'duck', 'lizard'],
+      },
+      {
+        property: 'name',
+        type: 'string',
+        direction: 'asc',
+      },
+    ]);
+
+    const result = sorter(mockItems).map((item) => item.name);
+    expect(result).toEqual(['david', 'alice', 'bob', 'charlie']);
+  });
+
+  it('handles missing categories', () => {
+    const mockItems = [
+      {
+        name: 'alice',
+      },
+      {
+        category: ['duck'],
+        name: 'bob',
+      },
+      {
+        category: ['lizard'],
+        name: 'charlie',
+      },
+      {
+        name: 'david',
+      },
+    ];
+
+    const sorter = createSorter([
+      {
+        property: 'category',
+        type: 'categorical',
+        hierarchy: ['lizard', 'duck', 'cow'],
+      },
+      {
+        property: 'name',
+        type: 'string',
+        direction: 'asc',
+      },
+    ]);
+
+    const result = sorter(mockItems).map((item) => item.name);
+    expect(result).toEqual(['bob', 'charlie', 'alice', 'david']);
+  });
+});
+
 describe('Order direction', () => {
   it('orders ascending with "asc"', () => {
     const mockItems = [
@@ -994,7 +1105,7 @@ describe('processProtocolSortRule', () => {
         property: 'category',
         direction: 'asc',
       };
-      expect(processProtocolSortRule(codebookVariables)(rule).type).toEqual('string');
+      expect(processProtocolSortRule(codebookVariables)(rule).type).toEqual('categorical');
     });
 
     it('ordinal', () => {

--- a/src/utils/createSorter.js
+++ b/src/utils/createSorter.js
@@ -95,19 +95,17 @@ const hierarchyFunction = ({ property, direction = 'desc', hierarchy = [] }) => 
 
   if (direction === 'asc') {
     if (firstIndex > secondIndex) {
-      return -1;
-    }
-
-    if (firstIndex < secondIndex) {
       return 1;
+    }
+    if (firstIndex < secondIndex) {
+      return -1;
     }
   } else {
     if (firstIndex < secondIndex) {
-      return -1;
-    }
-
-    if (firstIndex > secondIndex) {
       return 1;
+    }
+    if (firstIndex > secondIndex) {
+      return -1;
     }
   }
   return 0;

--- a/src/utils/createSorter.js
+++ b/src/utils/createSorter.js
@@ -175,7 +175,7 @@ const getSortFunction = (rule) => {
   const {
     property,
     direction = 'asc',
-    type, // REQUIRED! number, boolean, string, date, hierarchy
+    type, // REQUIRED! number, boolean, string, date, hierarchy, categorical
   } = rule;
 
   // LIFO/FIFO rule sorted by _createdIndex

--- a/src/utils/createSorter.js
+++ b/src/utils/createSorter.js
@@ -95,17 +95,17 @@ const hierarchyFunction = ({ property, direction = 'desc', hierarchy = [] }) => 
 
   if (direction === 'asc') {
     if (firstIndex > secondIndex) {
-      return 1;
+      return -1;
     }
     if (firstIndex < secondIndex) {
-      return -1;
+      return 1;
     }
   } else {
     if (firstIndex < secondIndex) {
-      return 1;
+      return -1;
     }
     if (firstIndex > secondIndex) {
-      return -1;
+      return 1;
     }
   }
   return 0;


### PR DESCRIPTION
Users have been able to configure rules for sorting by categorical variables in Architect, but they were being sorted as strings. **This PR fixes sorting functionality for categorical variables to actually sort by the values provided.**

The hierarchy for sorting is _determined by the order that the values are defined_ in the variable definition. This user-supplied hierarchy is assumed to be _high to low_, to maintain consistency with the hierarchy sort used currently for sorting by ordinal variables. 

In cases of items having multiple values in a category array, _presence of a category is ranked higher than absence of_. For instance [“A”, “B”] is considered higher in the hierarchy than [“A”].

