### PR TITLE
Fix/Null column added to network

### DIFF
--- a/src/containers/CategoricalList/CategoricalListItem.js
+++ b/src/containers/CategoricalList/CategoricalListItem.js
@@ -81,9 +81,8 @@ const CategoricalListItem = (props) => {
       {},
       {
         [variable]: value,
-        // because category can now be promptVariable or
-        // otherVariable we need to reset the alternate.
-        [resetVariable]: null,
+        // reset is used to clear the variable when a node is moved to a different bin
+        ...(!!resetVariable && { [resetVariable]: null }),
       },
       'drop',
     );


### PR DESCRIPTION
On categorical bin interfaces without an other variable option, "null" was being added as a variable in the network.

This fix checks if resetVariable is truthy before adding it to the network. resetVariable exists in cases where a node is moved from a non-other bin to an other bin, or from an other bin to a non-other bin.

Same change from fix in Fresco https://github.com/complexdatacollective/Fresco/pull/149